### PR TITLE
feat: add agentskill-learn skill for 110K+ skill discovery

### DIFF
--- a/marketplaces/default.json
+++ b/marketplaces/default.json
@@ -23,6 +23,20 @@
             ]
         },
         {
+            "name": "agentskill-learn",
+            "source": "./agentskill-learn",
+            "description": "Discover, install, and manage 110,000+ AI agent skills from agentskill.sh. Search by keyword, install mid-session, scan for security issues, and rate skills after use.",
+            "category": "productivity",
+            "keywords": [
+                "skills",
+                "marketplace",
+                "registry",
+                "install",
+                "discover",
+                "agentskill"
+            ]
+        },
+        {
             "name": "agent-memory",
             "source": "./agent-memory",
             "description": "Persist and retrieve repository-specific knowledge using AGENTS.md files. Use when you want to save important information about a codebase (build commands, code style, workflows) for future sessions.",

--- a/skills/agentskill-learn/SKILL.md
+++ b/skills/agentskill-learn/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: agentskill-learn
+description: Discover, install, and manage AI agent skills from agentskill.sh. Search 110,000+ skills by keyword, install them mid-session, scan for security issues, and rate skills after use. Use when users want to find new skills, install a skill, or browse trending skills.
+triggers:
+- learn
+- install skill
+- find skill
+- search skills
+- skill marketplace
+- trending skills
+---
+
+# agentskill.sh — Skill Discovery & Installation
+
+Browse, install, and manage 110,000+ AI agent skills from [agentskill.sh](https://agentskill.sh), the cross-platform skills registry.
+
+## Setup (First Use)
+
+This is a lightweight loader. On first use, fetch the full `/learn` skill for the complete experience:
+
+```bash
+# Use the add-skill extension to fetch the latest version from GitHub
+python3 .agents/skills/add-skill/scripts/fetch_skill.py "https://github.com/agentskill-sh/learn" "$(pwd)"
+```
+
+If `add-skill` is not available, fetch manually:
+
+```bash
+mkdir -p .agents/skills/learn
+curl -sL "https://raw.githubusercontent.com/agentskill-sh/learn/main/SKILL.md" -o .agents/skills/learn/SKILL.md
+```
+
+After installation, the full `/learn` skill handles everything below automatically with richer features including security scanning, auto-updates, and feedback.
+
+## Quick Start (Without Full Install)
+
+### Search for skills
+
+Use WebFetch to query:
+```
+GET https://agentskill.sh/api/agent/search?q=<query>
+```
+
+Returns JSON with matching skills: name, description, owner, slug, install count.
+
+### Install a specific skill
+
+```
+GET https://agentskill.sh/api/agent/skills/<owner>/<slug>/install
+```
+
+Returns the skill content. Write it to `.agents/skills/<slug>/SKILL.md`.
+
+### Browse trending skills
+
+```
+GET https://agentskill.sh/api/agent/search?section=trending
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/learn <query>` | Search skills by keyword |
+| `/learn @owner/slug` | Install a specific skill |
+| `/learn trending` | Show trending skills |
+| `/learn list` | Show installed skills |
+| `/learn update` | Check for skill updates |
+| `/learn scan <path>` | Security scan a skill before install |
+| `/learn feedback <slug> <score>` | Rate a skill (1-5) |
+
+## Why agentskill.sh?
+
+- **110,000+ skills** indexed from GitHub, curated registries, and community submissions
+- **Cross-platform**: works with OpenHands, Claude Code, Cursor, Copilot, Codex, and 15+ agents
+- **Security scanning**: every skill is pre-scanned before publication
+- **One command install**: no manual file copying


### PR DESCRIPTION
## What

Adds an `agentskill-learn` skill that connects OpenHands to the [agentskill.sh](https://agentskill.sh) registry, giving users access to 110,000+ cross-platform AI agent skills.

## Why

OpenHands users currently need to manually find and import skills. This skill adds a built-in discovery layer that lets agents search, install, and manage skills from the largest open skills registry.

The skill is a lightweight bootstrap (~65 lines) that fetches the full `/learn` skill from [agentskill-sh/learn](https://github.com/agentskill-sh/learn) on first use via the existing `add-skill` mechanism. This means:

- **No maintenance burden**: the bootstrap is stable and rarely changes
- **Always up-to-date**: the real skill is fetched fresh from GitHub
- **No duplication**: skill logic lives in one canonical repo

## Changes

- `skills/agentskill-learn/SKILL.md`: Bootstrap skill with quick-start API docs and setup instructions
- `marketplaces/default.json`: Added marketplace entry under "productivity" category

## How Tested

- Verified SKILL.md follows the OpenHands skill format (YAML frontmatter with name, description, triggers)
- Verified marketplace entry follows existing patterns (source, category, keywords)
- API endpoints tested: search, install, and trending all return valid JSON
