### PR TITLE
Add Bilig WorkPaper MCP catalog entry

### DIFF
--- a/integrations/catalog/bilig-workpaper.json
+++ b/integrations/catalog/bilig-workpaper.json
@@ -1,0 +1,34 @@
+{
+  "id": "bilig-workpaper",
+  "name": "Bilig WorkPaper",
+  "description": "Edit formula workbook inputs, recalculate, verify readback, and export JSON-backed WorkPaper state.",
+  "docsUrl": "https://github.com/proompteng/bilig/tree/main/packages/workpaper#readme",
+  "iconBg": "#0F766E",
+  "keywords": [
+    "spreadsheet",
+    "workbook",
+    "formula",
+    "recalculation",
+    "xlsx",
+    "readback",
+    "finance",
+    "agents"
+  ],
+  "kind": "mcp",
+  "defaultConnectionOptionId": "none",
+  "connectionOptions": [
+    {
+      "id": "none",
+      "provider": "mcp",
+      "transport": {
+        "kind": "shttp",
+        "url": "https://bilig.proompteng.ai/mcp",
+        "apiKeyOptional": true
+      },
+      "auth": {
+        "strategy": "none",
+        "apiKeyOptional": true
+      }
+    }
+  ]
+}

--- a/integrations/index.js
+++ b/integrations/index.js
@@ -3,6 +3,7 @@ import apify from "./catalog/apify.json" with { type: "json" };
 import atlassian from "./catalog/atlassian.json" with { type: "json" };
 import brave_search from "./catalog/brave-search.json" with { type: "json" };
 import browser_mcp from "./catalog/browser-mcp.json" with { type: "json" };
+import bilig_workpaper from "./catalog/bilig-workpaper.json" with { type: "json" };
 import clickhouse from "./catalog/clickhouse.json" with { type: "json" };
 import cloudflare_bindings from "./catalog/cloudflare-bindings.json" with { type: "json" };
 import cloudflare_browser_rendering from "./catalog/cloudflare-browser-rendering.json" with { type: "json" };
@@ -55,6 +56,7 @@ const DIRECT_INTEGRATIONS = [
   atlassian,
   brave_search,
   browser_mcp,
+  bilig_workpaper,
   clickhouse,
   cloudflare_bindings,
   cloudflare_browser_rendering,


### PR DESCRIPTION
## Description

Adds Bilig WorkPaper to the OpenHands integrations catalog as a remote MCP server.

Bilig WorkPaper gives agents a spreadsheet-style formula workbook they can operate through tools: read inputs, set cells, recalculate, verify formula readback, and export JSON-backed state without driving Excel or a browser UI.

This refresh keeps the existing PR scoped to one catalog entry plus the integrations index export. No duplicate Bilig PR or issue was opened.

## Changes

- Add `integrations/catalog/bilig-workpaper.json`
- Register `bilig-workpaper` in `integrations/index.js`
- Use the current `connectionOptions` schema with unauthenticated Streamable HTTP transport

## Validation

```bash
python3 -m json.tool integrations/catalog/bilig-workpaper.json >/dev/null
node --input-type=module -e "import('./integrations/index.js').then(m => { const x=m.INTEGRATION_CATALOG.find(i=>i.id==='bilig-workpaper'); if (!x) throw new Error('missing'); console.log(JSON.stringify({id:x.id,kind:x.kind,defaultConnectionOptionId:x.defaultConnectionOptionId,transport:x.connectionOptions[0].transport.kind,auth:x.connectionOptions[0].auth.strategy})) })"
git diff --check -- integrations/catalog/bilig-workpaper.json integrations/index.js
npm view @bilig/workpaper version
npm exec --yes --package @bilig/workpaper@latest -- bilig-evaluate --door agent-mcp --json
```

The local catalog import smoke printed:

```json
{"id":"bilig-workpaper","kind":"mcp","defaultConnectionOptionId":"none","transport":"shttp","auth":"none"}
```

Current public package proof:

- `npm view @bilig/workpaper version` returned `0.161.0`
- `npm exec --yes --package @bilig/workpaper@latest -- bilig-evaluate --door agent-mcp --json` returned `verified: true`
- The evaluator reported `@bilig/workpaper@0.161.0` and `xlsx-formula-recalc@0.161.0`
- It listed 8 MCP tools, edited `Inputs!B3`, changed expected ARR from `60000` to `96000`, persisted the WorkPaper JSON, restored readback, and confirmed restart readback

Current Bilig source proof: `proompteng/bilig@5a71e29818030e2251bc72bc2566ca18437c4e6d`.

Earlier full local validation also passed `python scripts/sync_extensions.py --check` and `uv run --group test pytest tests/` with `281` tests.
