### PR TITLE
fix(github-repo-monitor): silence 409 in fire_callback; document PATCH re-enable

### DIFF
--- a/skills/github-repo-monitor/SKILL.md
+++ b/skills/github-repo-monitor/SKILL.md
@@ -29,8 +29,11 @@ On every subsequent run:
 - When a conversation goes idle/finished/error the agent's final response
   is posted back as a GitHub comment.
 
-> **Local mode only.** This automation targets the local OpenHands setup
-> (`dev:automation` stack). A cloud/webhook variant is out of scope here.
+> **Cron polling vs. event triggers:** This skill uses cron polling and works in
+> any deployment. If `RUNTIME_URL` is set and does not contain `localhost` or
+> `127.0.0.1`, the environment can receive GitHub webhook events directly — prefer
+> an event-triggered automation (see the `openhands-automation` skill) rather than
+> polling. Use this skill only when `RUNTIME_URL` is unset, empty, or local.
 
 ---
 
@@ -68,6 +71,25 @@ function without GitHub credentials.
 ## Setup Workflow
 
 Follow these steps in order.
+
+### Step 0  -  Check deployment environment
+
+Check whether the environment can receive GitHub webhook events:
+
+```bash
+echo "RUNTIME_URL=${RUNTIME_URL}"
+```
+
+- If `RUNTIME_URL` is **set and does not contain `localhost` or `127.0.0.1`** →
+  tell the user:
+  *"Your environment has a reachable `RUNTIME_URL` (`$RUNTIME_URL`), so GitHub can
+  deliver events directly. An event-triggered automation (e.g. `pull_request.opened`
+  or `issue_comment.created`) using the `openhands-automation` skill would be more
+  immediate and efficient than cron polling. Continue with this skill only if you
+  specifically want polling."*
+  If the user confirms they want polling anyway, continue to Step 1.
+- If `RUNTIME_URL` is **unset, empty, or contains `localhost`/`127.0.0.1`** →
+  proceed directly to Step 1.
 
 ### Step 1  -  Verify GITHUB_TOKEN
 

--- a/skills/github-repo-monitor/SKILL.md
+++ b/skills/github-repo-monitor/SKILL.md
@@ -303,3 +303,5 @@ Each cron run executes `main.py`, which:
 | Same comment processed twice | `processed_comment_ids` cleared | State file was deleted; harmless but duplicate comment may appear |
 | Summary never posted | Conversation stuck in `running` | Open the conversation in the OpenHands UI; agent may need input |
 | No events detected after first run | `last_poll` in the future | Delete the state file to reset; it will be recreated on next run |
+| `Callback error (non-fatal): HTTP Error 409: Conflict` in run logs | Automation service auto-marks the run complete on process exit; explicit `fire_callback("COMPLETED")` at script end then conflicts | Fixed in `scripts/main.py` ≥ this version — the 409 is now caught and ignored silently |
+| Automation stops firing after updating it via PATCH | PATCH resets `enabled` to `false` | Follow every PATCH with `{"enabled": true}` to re-activate |

--- a/skills/github-repo-monitor/scripts/main.py
+++ b/skills/github-repo-monitor/scripts/main.py
@@ -98,6 +98,10 @@ def fire_callback(status: str = "COMPLETED", error: str | None = None) -> None:
     )
     try:
         urllib.request.urlopen(req)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 409:
+            return  # Run already marked complete by the automation service — ignore.
+        print(f"Callback error (non-fatal): {exc}")
     except Exception as exc:
         print(f"Callback error (non-fatal): {exc}")
 


### PR DESCRIPTION
## Problem 1 — Noisy 409 in every run log

Every run of a `github-repo-monitor` automation logs:

```
Callback error (non-fatal): HTTP Error 409: Conflict
```

**Root cause:** The automation service marks a run COMPLETED on process exit.
The explicit `fire_callback("COMPLETED")` call at the end of the script then
tries to write the same status a second time and receives HTTP 409 Conflict.
Because this was caught by the bare `except Exception` handler it was printed
on every run, giving the impression something had gone wrong.

**Fix (`scripts/main.py`):** Catch `urllib.error.HTTPError` before the bare
`Exception` and return silently on 409.

## Problem 2 — Vague 'local mode only' guidance

The previous intro callout said *'Local mode only'* without giving agents a
concrete way to decide whether the current environment can receive GitHub
webhook events. In production Kubernetes pods `AGENT_SERVER_URL` and `HOST`
are absent, but `RUNTIME_URL` **is** set to a reachable external URL.

**Fix (`SKILL.md`):**
- Replace the callout with an explicit `RUNTIME_URL`-based rule:
  set and not `localhost`/`127.0.0.1` → prefer event trigger;
  unset, empty, or local → use cron polling.
- Add **Step 0** to the Setup Workflow so the agent runs
  `echo "RUNTIME_URL=${RUNTIME_URL}"` and surfaces the event-trigger
  recommendation to the user before proceeding with polling setup.

## Additional docs (`SKILL.md` Troubleshooting table)

Two new rows:
| Symptom | Root cause | Fix |
|---|---|---|
| `Callback error (non-fatal): HTTP Error 409: Conflict` in run logs |
  Race between process-exit auto-complete and explicit callback |
  Fixed in `scripts/main.py` (this PR) |
| Automation stops firing after a PATCH update |
  PATCH resets `enabled` to `false` |
  Follow every PATCH with `{"enabled": true}` |

## Testing

Discovered and verified in a live `dev:automation` stack running
`github-repo-monitor` against `tofarr/polling-experiment`.
Production K8s pod env-var inventory confirmed `RUNTIME_URL` as the
correct discriminator (not `HOST` or `AGENT_SERVER_URL`).

_This PR was created by an AI agent (OpenHands) on behalf of the user._