### PR TITLE
Fix custom-codereview-guide: remove overbroad trigger, improve description

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -1,8 +1,6 @@
 ---
 name: custom-codereview-guide
-description: Repository-specific code review guidelines for OpenHands/extensions
-triggers:
-- /codereview
+description: Repository-specific code review guidelines for the OpenHands/extensions repo. Use when reviewing pull requests in this repository. Covers SDK documentation placement rules and pre-release catalog migration policy.
 ---
 
 # Extensions Repo — Code Review Guidelines


### PR DESCRIPTION
## What

Fixes the `.agents/skills/custom-codereview-guide.md` skill introduced in #340.

## Changes

1. **Remove `/codereview` trigger** — this repo-level customization skill shouldn't be a user-invokable slash command. The trigger also conflicts with the catalog `code-review` skill which uses the same `/codereview` trigger.

2. **Improve description** — per the [agentskills.io spec](https://agentskills.io), the `description` field should describe both what the skill does and when to use it. The previous description was generic; the new one specifies PR review context and the specific areas covered (SDK docs placement, catalog migration policy).

## How activation works without triggers

Per the agentskills spec, `name` and `description` are loaded at startup for all skills. The agent decides when to activate the full skill body based on description matching. For a repo-level code review guide, this is the right activation model — the agent should pick it up automatically when doing code review work in this repo, not only when a user types a slash command.