### PR TITLE
ci: use PyPI trusted publishing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,11 +13,8 @@ permissions:
   contents: read
 
 jobs:
-  publish:
-    name: Publish openhands-extensions to PyPI
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      !github.event.release.prerelease
+  build:
+    name: Build Python distributions
     runs-on: ubuntu-24.04
     timeout-minutes: 15
 
@@ -74,13 +71,34 @@ jobs:
       - name: Build package
         run: uv build
 
-      - name: Publish to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN_OPENHANDS }}
-        run: |
-          if [ -z "${UV_PUBLISH_TOKEN:-}" ]; then
-            echo "❌ Missing secret PYPI_TOKEN_OPENHANDS"
-            exit 1
-          fi
+      - name: Upload distributions
+        uses: actions/upload-artifact@v6
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
 
-          uv publish --token "$UV_PUBLISH_TOKEN" --check-url https://pypi.org/simple/
+  publish:
+    name: Publish openhands-extensions to PyPI
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      !github.event.release.prerelease
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/p/openhands-extensions
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v6
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- switch the PyPI publish workflow from a long-lived token secret to PyPI trusted publishing / OIDC
- split build and publish jobs so distributions are uploaded as artifacts before publishing
- bind the publish job to the `pypi` GitHub environment and request `id-token: write` only for that job

## Validation
- `uv build`
- `python -m pytest tests/test_version_alignment.py tests/test_catalogs.py tests/test_integration_catalog_in_sync.py -q`

## Follow-up setup
Configure a pending PyPI publisher for `openhands-extensions` with owner `OpenHands`, repository `extensions`, workflow `pypi-publish.yml`, and environment `pypi`.

_This PR was created by an AI agent (OpenHands) on behalf of Graham Neubig._
