### PR TITLE
refactor: align integration catalog read APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ See [`integrations/README.md`](integrations/README.md), [`automations/README.md`
 
 ### Python Package
 
-The integration catalog is also published as a Python package (`openhands-extensions`) so Python services read the same catalog data as JS consumers. The single source of truth is the hand-authored JSON asset `integrations/integration-catalog.json` (NOT generated from any `.mjs`/`.js` source). Each per-integration entry also exists as `integrations/catalog/<id>.json`; a CI parity test asserts the two never drift. Both the JS package (`@openhands/extensions/integrations`) and the Python package read that same JSON asset at runtime, so the two language bindings can never drift.
+The integration catalog is also published as a Python package (`openhands-extensions`) so Python services read the same catalog data as JS consumers. The single source of truth is the hand-authored JSON directory `integrations/catalog/<id>.json`; there is no separate provider file and no aggregate catalog JSON to maintain. Both the JS package (`@openhands/extensions/integrations`) and the Python package read those same per-integration JSON files and expose parallel read functions.
 
-The catalog is one array where each entry can carry oauth and/or mcp/http `connectionOptions`. `supportsOauth` / `supportsMcp` flags are derived at runtime. Use `listIntegrationCatalog({ mcp, oauth })` (JS) or `list_integration_catalog(mcp=, oauth=)` (Python) to filter by connector type - for example only integrations that support an oauth connector.
+Each catalog entry can carry oauth and/or mcp/http `connectionOptions`. `supportsOauth` / `supportsMcp` flags are derived at runtime. Use `listIntegrationCatalog({ mcp, oauth })` (JS) or `list_integration_catalog(mcp=, oauth=)` (Python) to filter by connector type - for example only integrations that support an oauth connector.
 
 ```python
 from openhands_extensions import (
@@ -73,7 +73,7 @@ from openhands_extensions import (
 all_integrations = list_integration_catalog()
 oauth_integrations = list_integration_catalog(oauth=True)      # only entries with an oauth connector
 mcp_integrations = list_integration_catalog(mcp=True)          # only entries with an mcp connector
-hubspot = get_integration_catalog_entry("hubspot")
+sample = get_integration_catalog_entry(all_integrations[0]["id"])
 ```
 
 Install from git (the hub backend consumes it this way):

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -18,10 +18,16 @@ integrations so clients can consume one source of truth.
 Each integration carries its OAuth/MCP connection data directly. Do not add a
 separate provider catalog or per-language provider data.
 
-Consumers can import the package export:
+Consumers should use the read functions exported by the package:
 
 ```js
-import { INTEGRATION_CATALOG } from "@openhands/extensions/integrations";
+import {
+  getIntegrationCatalogEntry,
+  listIntegrationCatalog,
+} from "@openhands/extensions/integrations";
+
+const catalog = listIntegrationCatalog();
+const entry = getIntegrationCatalogEntry(catalog[0].id);
 ```
 
 ## Migration from the MCP catalog

--- a/integrations/index.d.ts
+++ b/integrations/index.d.ts
@@ -122,11 +122,12 @@ export const INTEGRATION_CATALOG: IntegrationCatalogEntry[];
 /**
  * Return the full integration catalog, optionally filtered by connector type.
  * Reads the generated static import index over `integrations/catalog/<id>.json`.
- * Returns the cached array; callers must treat it as read-only.
+ * Returns an independent copy, matching the Python read API.
  */
 export function listIntegrationCatalog(
   filter?: IntegrationCatalogFilter,
 ): IntegrationCatalogEntry[];
+/** Return one integration catalog entry by id as an independent copy. */
 export function getIntegrationCatalogEntry(
   id: string,
 ): IntegrationCatalogEntry | undefined;

--- a/integrations/index.js
+++ b/integrations/index.js
@@ -7,6 +7,7 @@
  */
 import { INTEGRATION_CATALOG_ENTRIES } from "./catalog-index.js";
 
+const clone = (value) => JSON.parse(JSON.stringify(value));
 const INTEGRATIONS = INTEGRATION_CATALOG_ENTRIES;
 const INTEGRATION_BY_ID = new Map(INTEGRATIONS.map((entry) => [entry.id, entry]));
 
@@ -17,18 +18,25 @@ const entrySupportsOauth = (entry) =>
   entry.connectionOptions.some((option) => option.auth?.strategy === "oauth2");
 
 export const listIntegrationCatalog = (filter) => {
-  if (!filter) return INTEGRATIONS;
-  const { mcp, oauth } = filter;
-  if (mcp === undefined && oauth === undefined) return INTEGRATIONS;
-  return INTEGRATIONS.filter((entry) => {
-    const mcpOk = mcp === undefined || entrySupportsMcp(entry) === mcp;
-    const oauthOk = oauth === undefined || entrySupportsOauth(entry) === oauth;
-    return mcpOk && oauthOk;
-  });
+  const entries =
+    !filter || (filter.mcp === undefined && filter.oauth === undefined)
+      ? INTEGRATIONS
+      : INTEGRATIONS.filter((entry) => {
+          const mcpOk =
+            filter.mcp === undefined || entrySupportsMcp(entry) === filter.mcp;
+          const oauthOk =
+            filter.oauth === undefined ||
+            entrySupportsOauth(entry) === filter.oauth;
+          return mcpOk && oauthOk;
+        });
+  return clone(entries);
 };
 
-export const getIntegrationCatalogEntry = (id) => INTEGRATION_BY_ID.get(id);
+export const getIntegrationCatalogEntry = (id) => {
+  const entry = INTEGRATION_BY_ID.get(id);
+  return entry ? clone(entry) : undefined;
+};
 
-export const INTEGRATION_CATALOG = INTEGRATIONS;
+export const INTEGRATION_CATALOG = clone(INTEGRATIONS);
 
 export default INTEGRATION_CATALOG;

--- a/tests/test_integration_catalog_in_sync.py
+++ b/tests/test_integration_catalog_in_sync.py
@@ -96,10 +96,13 @@ def test_logo_metadata_is_serializable_and_language_agnostic() -> None:
 
 
 def test_get_integration_catalog_entry_round_trip() -> None:
-    github = openhands_extensions.get_integration_catalog_entry("github")
-    assert github is not None
-    assert github == next(
-        entry for entry in openhands_extensions.list_integration_catalog() if entry["id"] == "github"
+    sample_id = openhands_extensions.list_integration_catalog()[0]["id"]
+    sample = openhands_extensions.get_integration_catalog_entry(sample_id)
+    assert sample is not None
+    assert sample == next(
+        entry
+        for entry in openhands_extensions.list_integration_catalog()
+        if entry["id"] == sample_id
     )
     assert openhands_extensions.get_integration_catalog_entry("nope") is None
 
@@ -122,11 +125,12 @@ def test_js_reads_the_same_catalog_as_python() -> None:
     )
     assert json.loads(integrations) == openhands_extensions.list_integration_catalog()
 
-    github = _js_call(
+    sample_id = openhands_extensions.list_integration_catalog()[0]["id"]
+    sample = _js_call(
         "import { getIntegrationCatalogEntry } from './integrations/index.js';\n"
-        "process.stdout.write(JSON.stringify(getIntegrationCatalogEntry('github')));"
+        f"process.stdout.write(JSON.stringify(getIntegrationCatalogEntry({json.dumps(sample_id)})));"
     )
-    assert json.loads(github) == openhands_extensions.get_integration_catalog_entry("github")
+    assert json.loads(sample) == openhands_extensions.get_integration_catalog_entry(sample_id)
 
 
 def _js_filter(mcp, oauth) -> list[str]:
@@ -141,7 +145,11 @@ def _js_filter(mcp, oauth) -> list[str]:
 def test_filter_mcp_only() -> None:
     py_ids = {e["id"] for e in openhands_extensions.list_integration_catalog(mcp=True)}
     js_ids = set(_js_filter("true", "undefined"))
-    all_mcp = {e["id"] for e in openhands_extensions.list_integration_catalog() if _supports_mcp(e)}
+    all_mcp = {
+        e["id"]
+        for e in openhands_extensions.list_integration_catalog()
+        if _supports_mcp(e)
+    }
     assert py_ids == js_ids == all_mcp
     assert "filesystem" in py_ids
 
@@ -149,9 +157,13 @@ def test_filter_mcp_only() -> None:
 def test_filter_oauth_only() -> None:
     py_ids = {e["id"] for e in openhands_extensions.list_integration_catalog(oauth=True)}
     js_ids = set(_js_filter("undefined", "true"))
-    all_oauth = {e["id"] for e in openhands_extensions.list_integration_catalog() if _supports_oauth(e)}
+    all_oauth = {
+        e["id"]
+        for e in openhands_extensions.list_integration_catalog()
+        if _supports_oauth(e)
+    }
     assert py_ids == js_ids == all_oauth
-    assert "github" in py_ids
+    assert py_ids
 
 
 def test_filter_oauth_not_mcp() -> None:
@@ -181,24 +193,60 @@ def test_accessors_return_independent_copies() -> None:
     catalog_a[0]["__mutated"] = True
     assert "__mutated" not in openhands_extensions.list_integration_catalog()[0]
 
-    github = openhands_extensions.get_integration_catalog_entry("github")
-    assert github is not None
-    github["__mutated"] = True
-    assert "__mutated" not in openhands_extensions.get_integration_catalog_entry("github")
+    sample_id = openhands_extensions.list_integration_catalog()[0]["id"]
+    sample = openhands_extensions.get_integration_catalog_entry(sample_id)
+    assert sample is not None
+    sample["__mutated"] = True
+    assert "__mutated" not in openhands_extensions.get_integration_catalog_entry(sample_id)
 
     snapshot = openhands_extensions.INTEGRATION_CATALOG_SNAPSHOT
     snapshot["integrations"][0]["__mutated"] = True
     assert "__mutated" not in openhands_extensions.list_integration_catalog()[0]
 
 
-def test_hubspot_oauth_config_lives_on_connection_option() -> None:
-    hubspot = openhands_extensions.get_integration_catalog_entry("hubspot")
-    assert hubspot is not None
-    assert "registrationDefaults" not in hubspot
-    option = hubspot["connectionOptions"][0]
-    assert option["provider"] == "mcp"
-    assert option["transport"]["url"] == "https://mcp.hubspot.com"
-    oauth = option["auth"]["oauth"]
-    assert oauth["authorizationUrl"] == "https://mcp.hubspot.com/oauth/authorize/user"
-    assert oauth["tokenUrl"] == "https://mcp.hubspot.com/oauth/v3/token"
-    assert oauth["pkce"] is True
+def test_js_accessors_return_independent_copies() -> None:
+    sample_id = openhands_extensions.list_integration_catalog()[0]["id"]
+    expr = f"""
+        import {{
+          INTEGRATION_CATALOG,
+          getIntegrationCatalogEntry,
+          listIntegrationCatalog,
+        }} from './integrations/index.js';
+        const sampleId = {json.dumps(sample_id)};
+        const first = listIntegrationCatalog();
+        const second = listIntegrationCatalog();
+        first[0].__mutated = true;
+        const entry = getIntegrationCatalogEntry(sampleId);
+        entry.__mutated = true;
+        INTEGRATION_CATALOG[0].__mutated = true;
+        process.stdout.write(JSON.stringify({{
+          listsAreIndependent:
+            !('__mutated' in second[0]) &&
+            !('__mutated' in listIntegrationCatalog()[0]),
+          entryIsIndependent: !('__mutated' in getIntegrationCatalogEntry(sampleId)),
+        }}));
+    """
+    result = json.loads(_js_call(expr))
+    assert result == {"listsAreIndependent": True, "entryIsIndependent": True}
+
+
+def test_oauth_config_lives_on_connection_options() -> None:
+    oauth_entries = [
+        entry
+        for entry in openhands_extensions.list_integration_catalog()
+        if _supports_oauth(entry)
+    ]
+    assert oauth_entries
+    for entry in oauth_entries:
+        assert "registrationDefaults" not in entry
+        oauth_options = [
+            option
+            for option in entry["connectionOptions"]
+            if option.get("auth", {}).get("strategy") == "oauth2"
+        ]
+        assert oauth_options
+        for option in oauth_options:
+            assert "registrationDefaults" not in option
+            oauth = option["auth"].get("oauth")
+            if oauth is not None:
+                assert isinstance(oauth, dict)


### PR DESCRIPTION
## Summary

- Keep `integrations/catalog/<id>.json` documented as the only hand-authored integration source of truth; no provider file and no aggregate JSON.
- Make JS catalog read functions return independent copies, matching the Python read API behavior.
- Replace provider-specific catalog parity checks/examples with generic source-of-truth and OAuth-placement invariants.

## Validation

- `uv run pytest tests/test_integration_catalog_in_sync.py -q` → 15 passed
- `uv run pytest -q` → 364 passed

This PR was created by an AI agent (OpenHands) on behalf of Graham Neubig.

Closes #360
