### PR TITLE
feat(integrations): support custom request headers on MCP shttp/sse transports

### DIFF
--- a/integrations/catalog/datadog.json
+++ b/integrations/catalog/datadog.json
@@ -8,8 +8,9 @@
   ],
   "appUrl": "https://www.datadoghq.com",
   "docsUrl": "https://docs.datadoghq.com/bits_ai/mcp_server/setup/",
-  "notes": "Uses Datadog's official hosted MCP server. The default registration targets the US1 endpoint and can be edited for other Datadog sites.",
+  "notes": "Uses Datadog's official hosted MCP server. The MCP endpoint host is site-specific: use https://mcp.<site>.datadoghq.com/v1/mcp for your Datadog site (e.g. mcp.us5.datadoghq.com for US5). The default URL below targets US1 and can be edited in the install dialog.",
   "popularityRank": 35,
+  "installHint": "The Datadog MCP URL is site-specific. Edit the URL to https://mcp.<site>.datadoghq.com/v1/mcp for your Datadog site (for example https://mcp.us5.datadoghq.com/v1/mcp for US5, https://mcp.eu.datadoghq.com/v1/mcp for EU). Find your site at Organization Settings → Site in Datadog.",
   "connectionOptions": [
     {
       "id": "oauth",
@@ -27,7 +28,7 @@
       },
       "transport": {
         "kind": "shttp",
-        "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+        "url": "https://mcp.datadoghq.com/v1/mcp"
       }
     },
     {
@@ -38,7 +39,8 @@
       },
       "transport": {
         "kind": "shttp",
-        "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp",
+        "url": "https://mcp.datadoghq.com/v1/mcp",
+        "urlEditable": true,
         "headerFields": [
           {
             "key": "DD-API-KEY",

--- a/integrations/catalog/datadog.json
+++ b/integrations/catalog/datadog.json
@@ -29,6 +29,35 @@
         "kind": "shttp",
         "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
       }
+    },
+    {
+      "id": "api",
+      "provider": "mcp",
+      "auth": {
+        "strategy": "none"
+      },
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp",
+        "headerFields": [
+          {
+            "key": "DD-API-KEY",
+            "label": "Datadog API key",
+            "type": "password",
+            "required": true,
+            "placeholder": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "helperText": "Created in Datadog under Organization Settings → API Keys. Used to authenticate to the Datadog MCP server. See the [setup docs](https://docs.datadoghq.com/mcp_server/setup/?tab=other#authentication)."
+          },
+          {
+            "key": "DD-APPLICATION-KEY",
+            "label": "Datadog Application key",
+            "type": "password",
+            "required": true,
+            "placeholder": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "helperText": "Created in Datadog under Organization Settings → Application Keys. Grants the MCP server access to your Datadog data. See the [setup docs](https://docs.datadoghq.com/mcp_server/setup/?tab=other#authentication)."
+          }
+        ]
+      }
     }
   ]
 }

--- a/integrations/index.d.ts
+++ b/integrations/index.d.ts
@@ -27,6 +27,14 @@ export type IntegrationTransport =
        * `key: "Authorization"` is redundant and should be avoided.
        */
       headerFields?: MarketplaceField[];
+      /**
+       * When true, the install modal renders the URL as an editable input
+       * pre-filled with `url` instead of read-only. Use for servers whose
+       * host is region/account-specific (e.g. Datadog's
+       * `https://mcp.<site>.datadoghq.com/v1/mcp`); pair with the entry's
+       * `installHint` to tell users what to change.
+       */
+      urlEditable?: boolean;
     }
   | {
       kind: "sse";
@@ -34,6 +42,8 @@ export type IntegrationTransport =
       apiKeyOptional?: boolean;
       /** See {@link IntegrationTransport} `shttp` `headerFields`. */
       headerFields?: MarketplaceField[];
+      /** See {@link IntegrationTransport} `shttp` `urlEditable`. */
+      urlEditable?: boolean;
     }
   | {
       kind: "stdio";

--- a/integrations/index.d.ts
+++ b/integrations/index.d.ts
@@ -15,11 +15,25 @@ export type IntegrationTransport =
       kind: "shttp";
       url: string;
       apiKeyOptional?: boolean;
+      /**
+       * Named request headers the user must supply (e.g. Datadog's
+       * `DD-API-KEY` / `DD-APPLICATION-KEY`). Values are sent verbatim as
+       * headers on every MCP request. The direct analog of stdio's
+       * `envFields`: each entry renders one input in the install modal,
+       * `type: "password"` entries are secret-saved by default, and
+       * `required` entries are validated before submit. Composes with the
+       * `api_key`/`bearer`/`basic` auth strategies (whose Bearer token is
+       * folded into `Authorization` separately); a header field with
+       * `key: "Authorization"` is redundant and should be avoided.
+       */
+      headerFields?: MarketplaceField[];
     }
   | {
       kind: "sse";
       url: string;
       apiKeyOptional?: boolean;
+      /** See {@link IntegrationTransport} `shttp` `headerFields`. */
+      headerFields?: MarketplaceField[];
     }
   | {
       kind: "stdio";

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -79,9 +79,14 @@ def test_remote_no_auth_mcp_entries_are_intentionally_public():
     for entry in load_catalog_entries("integrations/catalog"):
         for option in entry["connectionOptions"]:
             transport = option.get("transport", {})
+            # An option with `headerFields` still requires the user to supply
+            # credentials (just via named headers, e.g. Datadog's
+            # DD-API-KEY/DD-APPLICATION-KEY), so it is NOT "public/no-auth".
+            has_header_credentials = bool(transport.get("headerFields"))
             if (
                 option["provider"] == "mcp"
                 and option["auth"]["strategy"] == "none"
+                and not has_header_credentials
                 and transport.get("url", "").startswith("https://")
             ):
                 actual.add(entry["id"])
@@ -98,7 +103,7 @@ def test_credential_fields_have_helper_text_and_link():
     for entry in load_catalog_entries("integrations/catalog"):
         for option in entry["connectionOptions"]:
             transport = option.get("transport", {})
-            for field_group in ("envFields", "argFields"):
+            for field_group in ("envFields", "argFields", "headerFields"):
                 for field in transport.get(field_group, []):
                     if field.get("type") == "password":
                         field_key = field.get("key", "<unknown>")


### PR DESCRIPTION
> _This PR was created by an AI agent (OpenHands) on behalf of @neubig._

Closes OpenHands/agent-canvas#2282.

## Summary

Adds `headerFields?: MarketplaceField[]` to the `shttp` / `sse` variants of `IntegrationTransport`, mirroring the `envFields`/`argFields` pattern on `stdio`. This lets a hosted MCP integration declare a list of named request headers the user must supply — the generalized mechanism behind header-based auth flows like **Datadog's `DD-API-KEY` / `DD-APPLICATION-KEY`** (https://docs.datadoghq.com/mcp_server/setup/?tab=other#authentication), which were previously expressible only via OAuth.

`headerFields` composes with the existing `api_key`/`bearer`/`basic`/`oauth2` strategies (the Bearer token from `api_key` is folded into `Authorization` separately) — no new auth-strategy enum value is needed.

## Changes

- `integrations/index.d.ts`: add `headerFields?: MarketplaceField[]` to `shttp` and `sse` transports.
- `integrations/catalog/datadog.json`: add a non-OAuth `api` connection option declaring `DD-API-KEY` and `DD-APPLICATION-KEY` as `headerFields`, so the marketplace install flow can surface the header-based path without Datadog Technology Partner Program enrollment.
- `tests/test_catalogs.py`:
  - `test_remote_no_auth_mcp_entries_are_intentionally_public` tightened to exclude options with `headerFields` (they still require credentials, just via named headers, so they are not \"public/no-auth\").
  - `test_credential_fields_have_helper_text_and_link` extended to validate `headerFields` password fields too.

## Why this is general

- **Any** MCP `shttp`/`sse` integration can declare the headers it needs — not a Datadog-specific hack.
- The matching frontend collection UI is tracked separately on agent-canvas (https://github.com/OpenHands/agent-canvas/issues/2008). The agent-canvas plumbing (`MCPServerConfig.headers`, `MCPSSEServer.headers`, `mcp-service.api.ts`, `use-update-mcp-server.ts`) and the backend (`software-agent-sdk` `mcp_router._RemoteMCPServerSpec.headers`, `fastmcp` transport, encrypted at rest by `settings/model.py`) already support arbitrary headers end-to-end.

## Test plan

- [x] `uv run --group test pytest -q` — 364 passed
- [x] `npm run build:integrations` — `catalog-index.js` unchanged (datadog.json already imported)
- [ ] CI green