### PR TITLE
fix(catalog): give HTTP connectors a real tool source (openApiUrl or MCP)

### DIFF
--- a/integrations/catalog/airtable.json
+++ b/integrations/catalog/airtable.json
@@ -13,7 +13,7 @@
   "connectionOptions": [
     {
       "id": "oauth",
-      "provider": "http",
+      "provider": "mcp",
       "auth": {
         "strategy": "oauth2",
         "oauth": {
@@ -25,14 +25,9 @@
           ]
         }
       },
-      "http": {
-        "apiBaseUrl": "https://api.airtable.com/v0",
-        "defaultTool": {
-          "name": "list_bases",
-          "description": "List Airtable bases the connected user granted access to.",
-          "method": "GET",
-          "path": "/meta/bases"
-        }
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.airtable.com/mcp"
       }
     },
     {

--- a/integrations/catalog/asana.json
+++ b/integrations/catalog/asana.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://app.asana.com/api/1.0",
-        "defaultTool": {
-          "name": "list_tasks",
-          "description": "List tasks visible to the connected Asana user.",
-          "method": "GET",
-          "path": "/tasks"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/Asana/openapi/master/defs/asana_oas.yaml"
       }
     }
   ]

--- a/integrations/catalog/bitbucket.json
+++ b/integrations/catalog/bitbucket.json
@@ -27,12 +27,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.bitbucket.org/2.0",
-        "defaultTool": {
-          "name": "get_current_user",
-          "description": "Fetch the authenticated Bitbucket user profile.",
-          "method": "GET",
-          "path": "/user"
-        }
+        "openApiUrl": "https://developer.atlassian.com/cloud/bitbucket/swagger.json"
       }
     }
   ]

--- a/integrations/catalog/box.json
+++ b/integrations/catalog/box.json
@@ -27,12 +27,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.box.com/2.0",
-        "defaultTool": {
-          "name": "list_root_items",
-          "description": "List files and folders in the Box root folder.",
-          "method": "GET",
-          "path": "/folders/0/items"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/box/box-openapi/main/openapi.json"
       }
     }
   ]

--- a/integrations/catalog/canva.json
+++ b/integrations/catalog/canva.json
@@ -23,12 +23,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.canva.com/rest/v1",
-        "defaultTool": {
-          "name": "list_designs",
-          "description": "List Canva designs available to the connected user.",
-          "method": "GET",
-          "path": "/designs"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/canva-sdks/canva-connect-api-starter-kit/main/openapi/spec.yml"
       }
     }
   ]

--- a/integrations/catalog/clickup.json
+++ b/integrations/catalog/clickup.json
@@ -13,7 +13,7 @@
   "connectionOptions": [
     {
       "id": "oauth",
-      "provider": "http",
+      "provider": "mcp",
       "auth": {
         "strategy": "oauth2",
         "oauth": {
@@ -22,14 +22,9 @@
           "scopes": []
         }
       },
-      "http": {
-        "apiBaseUrl": "https://api.clickup.com/api/v2",
-        "defaultTool": {
-          "name": "list_workspaces",
-          "description": "List ClickUp workspaces available to the connected user.",
-          "method": "GET",
-          "path": "/team"
-        }
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.clickup.com/mcp"
       }
     }
   ]

--- a/integrations/catalog/confluence.json
+++ b/integrations/catalog/confluence.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.atlassian.com/ex/confluence/{cloudId}",
-        "defaultTool": {
-          "name": "list_spaces",
-          "description": "List Confluence spaces available to the connected user.",
-          "method": "GET",
-          "path": "/wiki/api/v2/spaces"
-        }
+        "openApiUrl": "https://developer.atlassian.com/cloud/confluence/swagger.json"
       }
     }
   ]

--- a/integrations/catalog/discord.json
+++ b/integrations/catalog/discord.json
@@ -27,12 +27,7 @@
       },
       "http": {
         "apiBaseUrl": "https://discord.com/api/v10",
-        "defaultTool": {
-          "name": "list_guilds",
-          "description": "List Discord guilds available to the connected user.",
-          "method": "GET",
-          "path": "/users/@me/guilds"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json"
       }
     }
   ]

--- a/integrations/catalog/dropbox.json
+++ b/integrations/catalog/dropbox.json
@@ -13,7 +13,7 @@
   "connectionOptions": [
     {
       "id": "oauth",
-      "provider": "http",
+      "provider": "mcp",
       "auth": {
         "strategy": "oauth2",
         "oauth": {
@@ -24,14 +24,9 @@
           ]
         }
       },
-      "http": {
-        "apiBaseUrl": "https://api.dropboxapi.com/2",
-        "defaultTool": {
-          "name": "list_root_folder",
-          "description": "List entries in the root Dropbox folder.",
-          "method": "POST",
-          "path": "/files/list_folder"
-        }
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.dropbox.com/mcp"
       }
     }
   ]

--- a/integrations/catalog/figma.json
+++ b/integrations/catalog/figma.json
@@ -29,12 +29,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.figma.com",
-        "defaultTool": {
-          "name": "get_file",
-          "description": "Fetch a Figma file by key.",
-          "method": "GET",
-          "path": "/v1/files/{fileKey}"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/figma/rest-api-spec/main/openapi/openapi.yaml"
       }
     },
     {

--- a/integrations/catalog/freshdesk.json
+++ b/integrations/catalog/freshdesk.json
@@ -13,7 +13,7 @@
   "connectionOptions": [
     {
       "id": "oauth",
-      "provider": "http",
+      "provider": "mcp",
       "auth": {
         "strategy": "oauth2",
         "oauth": {
@@ -24,14 +24,9 @@
           ]
         }
       },
-      "http": {
-        "apiBaseUrl": "https://{domain}.freshdesk.com/api/v2",
-        "defaultTool": {
-          "name": "list_tickets",
-          "description": "List Freshdesk tickets for the connected account.",
-          "method": "GET",
-          "path": "/tickets"
-        }
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.freshdesk.com/mcp"
       }
     }
   ]

--- a/integrations/catalog/github.json
+++ b/integrations/catalog/github.json
@@ -30,13 +30,7 @@
         "url": "https://api.githubcopilot.com/mcp/"
       },
       "http": {
-        "apiBaseUrl": "https://api.github.com",
-        "defaultTool": {
-          "name": "get_authenticated_user",
-          "description": "Fetch the authenticated GitHub user profile.",
-          "method": "GET",
-          "path": "/user"
-        }
+        "apiBaseUrl": "https://api.github.com"
       }
     },
     {

--- a/integrations/catalog/gitlab.json
+++ b/integrations/catalog/gitlab.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://gitlab.com/api/v4",
-        "defaultTool": {
-          "name": "get_current_user",
-          "description": "Fetch the authenticated GitLab user profile.",
-          "method": "GET",
-          "path": "/user"
-        }
+        "openApiUrl": "https://gitlab.com/gitlab-org/gitlab/-/raw/master/doc/api/openapi/openapi_v3.yaml"
       }
     }
   ]

--- a/integrations/catalog/gmail.json
+++ b/integrations/catalog/gmail.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://gmail.googleapis.com",
-        "defaultTool": {
-          "name": "list_messages",
-          "description": "List Gmail messages for the authenticated user.",
-          "method": "GET",
-          "path": "/gmail/v1/users/me/messages"
-        }
+        "openApiUrl": "https://www.googleapis.com/discovery/v1/apis/gmail/v1/rest"
       }
     }
   ]

--- a/integrations/catalog/google-calendar.json
+++ b/integrations/catalog/google-calendar.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://www.googleapis.com/calendar/v3",
-        "defaultTool": {
-          "name": "list_events",
-          "description": "List events from the user's primary Google Calendar.",
-          "method": "GET",
-          "path": "/calendars/primary/events"
-        }
+        "openApiUrl": "https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest"
       }
     }
   ]

--- a/integrations/catalog/google-docs.json
+++ b/integrations/catalog/google-docs.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://docs.googleapis.com",
-        "defaultTool": {
-          "name": "get_document",
-          "description": "Fetch a Google Docs document by ID.",
-          "method": "GET",
-          "path": "/v1/documents/{documentId}"
-        }
+        "openApiUrl": "https://www.googleapis.com/discovery/v1/apis/docs/v1/rest"
       }
     }
   ]

--- a/integrations/catalog/google-drive.json
+++ b/integrations/catalog/google-drive.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://www.googleapis.com/drive/v3",
-        "defaultTool": {
-          "name": "list_files",
-          "description": "List Drive files visible to the connected user.",
-          "method": "GET",
-          "path": "/files"
-        }
+        "openApiUrl": "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest"
       }
     }
   ]

--- a/integrations/catalog/google-sheets.json
+++ b/integrations/catalog/google-sheets.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://sheets.googleapis.com",
-        "defaultTool": {
-          "name": "get_spreadsheet",
-          "description": "Fetch spreadsheet metadata and sheets by ID.",
-          "method": "GET",
-          "path": "/v4/spreadsheets/{spreadsheetId}"
-        }
+        "openApiUrl": "https://www.googleapis.com/discovery/v1/apis/sheets/v4/rest"
       }
     }
   ]

--- a/integrations/catalog/intercom.json
+++ b/integrations/catalog/intercom.json
@@ -27,12 +27,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.intercom.io",
-        "defaultTool": {
-          "name": "list_contacts",
-          "description": "List Intercom contacts for the connected workspace.",
-          "method": "GET",
-          "path": "/contacts"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/intercom/Intercom-OpenAPI/main/descriptions/0/api.intercom.io.yaml"
       }
     }
   ]

--- a/integrations/catalog/jira.json
+++ b/integrations/catalog/jira.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.atlassian.com/ex/jira/{cloudId}",
-        "defaultTool": {
-          "name": "list_projects",
-          "description": "List Jira projects available to the connected user.",
-          "method": "GET",
-          "path": "/rest/api/3/project/search"
-        }
+        "openApiUrl": "https://developer.atlassian.com/cloud/jira/platform/swagger.json"
       }
     }
   ]

--- a/integrations/catalog/linear.json
+++ b/integrations/catalog/linear.json
@@ -13,7 +13,7 @@
   "connectionOptions": [
     {
       "id": "oauth",
-      "provider": "http",
+      "provider": "mcp",
       "auth": {
         "strategy": "oauth2",
         "oauth": {
@@ -24,14 +24,9 @@
           ]
         }
       },
-      "http": {
-        "apiBaseUrl": "https://api.linear.app",
-        "defaultTool": {
-          "name": "list_issues",
-          "description": "Query issues from Linear via GraphQL.",
-          "method": "POST",
-          "path": "/graphql"
-        }
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.linear.app/mcp"
       }
     },
     {
@@ -59,5 +54,5 @@
     "tasks",
     "tickets"
   ],
-  "installHint": "Authenticate with a Linear API key (Linear \u2192 Settings \u2192 Security & access) \u2014 sent as a Bearer token. Optional when the endpoint accepts your OAuth session."
+  "installHint": "Authenticate with a Linear API key (Linear → Settings → Security & access) — sent as a Bearer token. Optional when the endpoint accepts your OAuth session."
 }

--- a/integrations/catalog/mailchimp.json
+++ b/integrations/catalog/mailchimp.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://{dc}.api.mailchimp.com/3.0",
-        "defaultTool": {
-          "name": "list_audiences",
-          "description": "List Mailchimp audiences for the connected account.",
-          "method": "GET",
-          "path": "/lists"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/main/spec/marketing.json"
       }
     }
   ]

--- a/integrations/catalog/microsoft-outlook.json
+++ b/integrations/catalog/microsoft-outlook.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://graph.microsoft.com/v1.0",
-        "defaultTool": {
-          "name": "list_messages",
-          "description": "List Outlook messages for the signed-in user.",
-          "method": "GET",
-          "path": "/me/messages"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml"
       }
     }
   ]

--- a/integrations/catalog/microsoft-teams.json
+++ b/integrations/catalog/microsoft-teams.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://graph.microsoft.com/v1.0",
-        "defaultTool": {
-          "name": "list_teams",
-          "description": "List Microsoft Teams joined by the signed-in user.",
-          "method": "GET",
-          "path": "/me/joinedTeams"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml"
       }
     }
   ]

--- a/integrations/catalog/miro.json
+++ b/integrations/catalog/miro.json
@@ -13,7 +13,7 @@
   "connectionOptions": [
     {
       "id": "oauth",
-      "provider": "http",
+      "provider": "mcp",
       "auth": {
         "strategy": "oauth2",
         "oauth": {
@@ -24,14 +24,9 @@
           ]
         }
       },
-      "http": {
-        "apiBaseUrl": "https://api.miro.com/v2",
-        "defaultTool": {
-          "name": "list_boards",
-          "description": "List Miro boards available to the connected user.",
-          "method": "GET",
-          "path": "/boards"
-        }
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.miro.com/mcp"
       }
     }
   ]

--- a/integrations/catalog/monday.json
+++ b/integrations/catalog/monday.json
@@ -13,7 +13,7 @@
   "connectionOptions": [
     {
       "id": "oauth",
-      "provider": "http",
+      "provider": "mcp",
       "auth": {
         "strategy": "oauth2",
         "oauth": {
@@ -24,14 +24,9 @@
           ]
         }
       },
-      "http": {
-        "apiBaseUrl": "https://api.monday.com/v2",
-        "defaultTool": {
-          "name": "list_boards",
-          "description": "Query boards from Monday.com.",
-          "method": "POST",
-          "path": "/"
-        }
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.monday.com/mcp"
       }
     }
   ]

--- a/integrations/catalog/netlify.json
+++ b/integrations/catalog/netlify.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.netlify.com/api/v1",
-        "defaultTool": {
-          "name": "list_sites",
-          "description": "List Netlify sites available to the connected user.",
-          "method": "GET",
-          "path": "/sites"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/netlify/open-api/master/swagger.yml"
       }
     }
   ]

--- a/integrations/catalog/okta.json
+++ b/integrations/catalog/okta.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://{yourOktaDomain}/api/v1",
-        "defaultTool": {
-          "name": "list_users",
-          "description": "List Okta users for the connected org.",
-          "method": "GET",
-          "path": "/users"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/okta/okta-management-openapi-spec/master/dist/current/management-minimal.yaml"
       }
     }
   ]

--- a/integrations/catalog/onedrive.json
+++ b/integrations/catalog/onedrive.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://graph.microsoft.com/v1.0",
-        "defaultTool": {
-          "name": "list_drive_items",
-          "description": "List OneDrive items in the root folder.",
-          "method": "GET",
-          "path": "/me/drive/root/children"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml"
       }
     }
   ]

--- a/integrations/catalog/pipedrive.json
+++ b/integrations/catalog/pipedrive.json
@@ -27,12 +27,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.pipedrive.com/v1",
-        "defaultTool": {
-          "name": "list_persons",
-          "description": "List Pipedrive people visible to the connected user.",
-          "method": "GET",
-          "path": "/persons"
-        }
+        "openApiUrl": "https://developers.pipedrive.com/docs/api/v1/openapi.json"
       }
     }
   ]

--- a/integrations/catalog/plaid.json
+++ b/integrations/catalog/plaid.json
@@ -19,12 +19,7 @@
       },
       "http": {
         "apiBaseUrl": "https://production.plaid.com",
-        "defaultTool": {
-          "name": "get_accounts",
-          "description": "Fetch accounts for a connected Plaid item.",
-          "method": "POST",
-          "path": "/accounts/get"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/plaid/plaid-openapi/master/2020-09-14.yml"
       }
     }
   ]

--- a/integrations/catalog/posthog.json
+++ b/integrations/catalog/posthog.json
@@ -13,7 +13,7 @@
   "connectionOptions": [
     {
       "id": "oauth",
-      "provider": "http",
+      "provider": "mcp",
       "auth": {
         "strategy": "oauth2",
         "oauth": {
@@ -24,14 +24,9 @@
           ]
         }
       },
-      "http": {
-        "apiBaseUrl": "https://us.posthog.com/api",
-        "defaultTool": {
-          "name": "list_projects",
-          "description": "List PostHog projects available to the connected user.",
-          "method": "GET",
-          "path": "/projects/"
-        }
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.posthog.com/mcp"
       }
     }
   ]

--- a/integrations/catalog/sentry.json
+++ b/integrations/catalog/sentry.json
@@ -28,12 +28,7 @@
       },
       "http": {
         "apiBaseUrl": "https://sentry.io/api/0",
-        "defaultTool": {
-          "name": "list_organizations",
-          "description": "List Sentry organizations available to the connected user.",
-          "method": "GET",
-          "path": "/organizations/"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/getsentry/sentry-api-schema/main/openapi-derefed.json"
       }
     },
     {

--- a/integrations/catalog/sharepoint.json
+++ b/integrations/catalog/sharepoint.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://graph.microsoft.com/v1.0",
-        "defaultTool": {
-          "name": "get_root_site",
-          "description": "Fetch the SharePoint root site through Microsoft Graph.",
-          "method": "GET",
-          "path": "/sites/root"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml"
       }
     }
   ]

--- a/integrations/catalog/stripe.json
+++ b/integrations/catalog/stripe.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.stripe.com/v1",
-        "defaultTool": {
-          "name": "list_customers",
-          "description": "List Stripe customers from the connected account.",
-          "method": "GET",
-          "path": "/customers"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/stripe/openapi/master/latest/openapi.spec3.json"
       }
     },
     {

--- a/integrations/catalog/supabase.json
+++ b/integrations/catalog/supabase.json
@@ -13,7 +13,7 @@
   "connectionOptions": [
     {
       "id": "oauth",
-      "provider": "http",
+      "provider": "mcp",
       "auth": {
         "strategy": "oauth2",
         "oauth": {
@@ -22,14 +22,9 @@
           "scopes": []
         }
       },
-      "http": {
-        "apiBaseUrl": "https://api.supabase.com/v1",
-        "defaultTool": {
-          "name": "list_projects",
-          "description": "List Supabase projects available to the connected user.",
-          "method": "GET",
-          "path": "/projects"
-        }
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.supabase.com/mcp"
       }
     },
     {

--- a/integrations/catalog/trello.json
+++ b/integrations/catalog/trello.json
@@ -19,12 +19,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.trello.com/1",
-        "defaultTool": {
-          "name": "list_boards",
-          "description": "List Trello boards visible to the authenticated member.",
-          "method": "GET",
-          "path": "/members/me/boards"
-        }
+        "openApiUrl": "https://developer.atlassian.com/cloud/trello/swagger.json"
       }
     }
   ]

--- a/integrations/catalog/vercel.json
+++ b/integrations/catalog/vercel.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.vercel.com",
-        "defaultTool": {
-          "name": "list_projects",
-          "description": "List Vercel projects available to the connected user.",
-          "method": "GET",
-          "path": "/v9/projects"
-        }
+        "openApiUrl": "https://openapi.vercel.sh/"
       }
     }
   ]

--- a/integrations/catalog/xero.json
+++ b/integrations/catalog/xero.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.xero.com/api.xro/2.0",
-        "defaultTool": {
-          "name": "list_contacts",
-          "description": "List Xero contacts for the connected tenant.",
-          "method": "GET",
-          "path": "/Contacts"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/XeroAPI/Xero-OpenAPI/master/xero_accounting.yaml"
       }
     }
   ]

--- a/integrations/catalog/zoom.json
+++ b/integrations/catalog/zoom.json
@@ -26,12 +26,7 @@
       },
       "http": {
         "apiBaseUrl": "https://api.zoom.us/v2",
-        "defaultTool": {
-          "name": "list_meetings",
-          "description": "List Zoom meetings for the connected user.",
-          "method": "GET",
-          "path": "/users/me/meetings"
-        }
+        "openApiUrl": "https://raw.githubusercontent.com/zoom/api/master/openapi.v2.json"
       }
     }
   ]


### PR DESCRIPTION
## Summary

Closes #366.

44 catalog connectors were defined as `provider: "http"` with a hand-authored
`defaultTool` and **no** `openApiUrl` on their first connection option. The
`defaultTool` is a single hardcoded request template that only ever exposes
one tool per provider, under-represents the API, and can drift from the real
API surface. This PR gives every affected connector a real, machine-readable
tool source and removes the obsolete `defaultTool`.

For each affected connector, the first connection option now either:

1. **keeps `provider: "http"` and gains an `http.openApiUrl`** pointing at the
   provider's published OpenAPI / Google Discovery / API-spec document so the
   full tool set can be generated from the schema (preferred when the provider
   publishes a machine-readable spec), **or**
2. **migrates to `provider: "mcp"`** with a `transport.url` pointing at the
   provider's official hosted MCP server (Streamable HTTP) so tools are
   discovered live via `tools/list` (used when the provider has an official
   hosted MCP server and no convenient OpenAPI document).

In both cases the now-obsolete `http.defaultTool` field is removed.

`github` is handled separately: its `mcp` connection option carried a dead
`defaultTool` (MCP discovers tools live, so the field was harmless but
inconsistent). That field is removed; `github`'s `provider`/`transport` are
unchanged.

`notion` and `elevenlabs` already had an `openApiUrl` and are **not** touched.

Only `integrations/catalog/*.json` files are modified (40 files). All other
fields (OAuth URLs, scopes, auth strategy, categories, logos, keywords, etc.)
are preserved. JSON formatting (2-space indent, trailing newline) matches the
existing files.

## Per-connector resolution

### Option 1 — `openApiUrl` added (kept `provider: "http"`)

| Connector | Spec URL |
|---|---|
| asana | `https://raw.githubusercontent.com/Asana/openapi/master/defs/asana_oas.yaml` (OpenAPI 3.0, official `Asana/openapi`) |
| bitbucket | `https://developer.atlassian.com/cloud/bitbucket/swagger.json` (Swagger 2.0, Atlassian developer docs) |
| box | `https://raw.githubusercontent.com/box/box-openapi/main/openapi.json` (OpenAPI 3.0.2, official `box/box-openapi`) |
| canva | `https://raw.githubusercontent.com/canva-sdks/canva-connect-api-starter-kit/main/openapi/spec.yml` (official Canva Connect SDK repo) |
| confluence | `https://developer.atlassian.com/cloud/confluence/swagger.json` (OpenAPI 3.0.1, Atlassian developer docs) |
| discord | `https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json` (official `discord/discord-api-spec`) |
| figma | `https://raw.githubusercontent.com/figma/rest-api-spec/main/openapi/openapi.yaml` (OpenAPI 3.1, official `figma/rest-api-spec`) |
| gitlab | `https://gitlab.com/gitlab-org/gitlab/-/raw/master/doc/api/openapi/openapi_v3.yaml` (OpenAPI 3.0, official GitLab repo) |
| gmail | `https://www.googleapis.com/discovery/v1/apis/gmail/v1/rest` (Google Discovery) |
| google-calendar | `https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest` (Google Discovery) |
| google-docs | `https://www.googleapis.com/discovery/v1/apis/docs/v1/rest` (Google Discovery) |
| google-drive | `https://www.googleapis.com/discovery/v1/apis/drive/v3/rest` (Google Discovery) |
| google-sheets | `https://www.googleapis.com/discovery/v1/apis/sheets/v4/rest` (Google Discovery) |
| intercom | `https://raw.githubusercontent.com/intercom/Intercom-OpenAPI/main/descriptions/0/api.intercom.io.yaml` (official `intercom/Intercom-OpenAPI`) |
| jira | `https://developer.atlassian.com/cloud/jira/platform/swagger.json` (OpenAPI, Atlassian Jira platform docs) |
| mailchimp | `https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/main/spec/marketing.json` (official Mailchimp client-lib codegen spec) |
| microsoft-outlook | `https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml` (Microsoft Graph OpenAPI 3.0.4) |
| microsoft-teams | `https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml` (Microsoft Graph OpenAPI 3.0.4) |
| netlify | `https://raw.githubusercontent.com/netlify/open-api/master/swagger.yml` (Swagger 2.0, official `netlify/open-api`) |
| okta | `https://raw.githubusercontent.com/okta/okta-management-openapi-spec/master/dist/current/management-minimal.yaml` (OpenAPI 3.0.3, official Okta management spec) |
| onedrive | `https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml` (Microsoft Graph OpenAPI 3.0.4) |
| pipedrive | `https://developers.pipedrive.com/docs/api/v1/openapi.json` (Pipedrive developer docs) |
| plaid | `https://raw.githubusercontent.com/plaid/plaid-openapi/master/2020-09-14.yml` (OpenAPI 3.0.0, official `plaid/plaid-openapi`) |
| sentry | `https://raw.githubusercontent.com/getsentry/sentry-api-schema/main/openapi-derefed.json` (OpenAPI 3.0.3, official `getsentry/sentry-api-schema`) |
| sharepoint | `https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml` (Microsoft Graph OpenAPI 3.0.4) |
| stripe | `https://raw.githubusercontent.com/stripe/openapi/master/latest/openapi.spec3.json` (OpenAPI 3.0.0, official `stripe/openapi`) |
| trello | `https://developer.atlassian.com/cloud/trello/swagger.json` (Swagger 2.0, Atlassian developer docs) |
| vercel | `https://openapi.vercel.sh/` (OpenAPI 3.0.3, Vercel's own hosted spec) |
| xero | `https://raw.githubusercontent.com/XeroAPI/Xero-OpenAPI/master/xero_accounting.yaml` (OpenAPI 3.0.0, official `XeroAPI/Xero-OpenAPI`) |
| zoom | `https://raw.githubusercontent.com/zoom/api/master/openapi.v2.json` (Swagger 2.0, official `zoom/api`) |

### Option 2 — migrated to `provider: "mcp"` (official hosted MCP server)

| Connector | MCP server URL |
|---|---|
| airtable | `https://mcp.airtable.com/mcp` |
| clickup | `https://mcp.clickup.com/mcp` |
| dropbox | `https://mcp.dropbox.com/mcp` |
| freshdesk | `https://mcp.freshdesk.com/mcp` |
| linear | `https://mcp.linear.app/mcp` |
| miro | `https://mcp.miro.com/mcp` |
| monday | `https://mcp.monday.com/mcp` |
| posthog | `https://mcp.posthog.com/mcp` |
| supabase | `https://mcp.supabase.com/mcp` |

All MCP URLs were verified to respond with `401`/`405` (i.e. a live
authenticated MCP endpoint) rather than a 404/redirect, and each is documented
by the provider as their official hosted MCP server (Streamable HTTP).

### `github`

Only the dead `defaultTool` was removed from its `mcp` option.
`provider`/`transport`/`http.apiBaseUrl` are unchanged.

## Could not resolve (left unchanged — need a human)

These connectors publish **no public machine-readable OpenAPI** and have **no
official hosted MCP server**. Per the issue instructions they are left
unchanged (their `defaultTool` remains) and listed here for a human to decide:

| Connector | Why unresolved |
|---|---|
| quickbooks | Intuit publishes no machine-readable OpenAPI for the QuickBooks V3 REST API (the developer portal is an SPA returning HTML); no official hosted MCP server exists. |
| salesforce | Salesforce's hosted MCP (Agentforce) is org-specific — the URL is configured per-org in Setup and there is no single public endpoint; no public OpenAPI for the Salesforce REST API. |
| servicenow | ServiceNow OpenAPI is only exportable from within a given instance (instance-specific URLs); no public hosted spec or official MCP server. |
| shopify | Shopify's only official MCP offering is the stdio `@shopify/dev-mcp` (docs search, not the Admin REST API); no clean public OpenAPI for the Admin REST API and no hosted HTTP MCP server. |
| zendesk | `mcp.zendesk.com` redirects to the help center (no MCP); Zendesk publishes no public machine-readable OpenAPI spec for its REST API. |

## Verification

A Python scan (`/tmp/verify_catalog_366.py`, not committed) over
`integrations/catalog/*.json` asserts:

- No `http` connection option has a `defaultTool` without an `openApiUrl`
  (except the 5 unresolved connectors above, which are intentionally left
  unchanged and listed).
- `github`'s `mcp` option has no `defaultTool`.
- Every formerly-affected connector either has an `openApiUrl` or is
  `provider: "mcp"` with a `transport.url`.

Result:

```
PASS
Remaining defaultTool entries in catalog: ['notion#0', 'quickbooks#0', 'salesforce#0', 'servicenow#0', 'shopify#0', 'zendesk#0']
  notion#0 is expected (notion already had openApiUrl, unchanged).
  Unresolved (left unchanged, listed in PR): ['quickbooks', 'salesforce', 'servicenow', 'shopify', 'zendesk']
Affected connectors resolved: 39
```

(`notion#0` keeps its `defaultTool` because it already had an `openApiUrl` and
is explicitly out of scope per the issue.)

The repo's existing test suite passes unchanged (no test referenced
`defaultTool`):

```
uv run --group test python -m pytest -q  →  364 passed
```

`git status -sb` shows only the 40 catalog JSON files modified.

---

This PR was created by an AI agent (OpenHands) on behalf of @neubig.