### PR TITLE
fix(release): annotate _version.py for release-please Generic updater

### DIFF
--- a/python/openhands_extensions/_version.py
+++ b/python/openhands_extensions/_version.py
@@ -16,6 +16,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 #: Fallback used only when the package is not installed (no dist metadata).
 #: Kept in lock-step with pyproject.toml/package.json by the version test.
+# x-release-please-update-version
 _FALLBACK_VERSION = "0.6.0"
 
 try:


### PR DESCRIPTION
## Summary
release-please lists `python/openhands_extensions/_version.py` as a plain extra-file (Generic updater), but the Generic updater only replaces a version string marked with the `x-release-please-update-version` annotation. Without it, `_version.py` was never bumped, so the release PR's `test_version_alignment` failed (`_version.py` stayed 0.6.0 while `package.json` bumped to 0.7.0).

Add the annotation above `_FALLBACK_VERSION`. This unblocks the 0.7.0 release PR #354.

## Validation
- `test_version_alignment` passes (0.6.0 consistent).

## AI disclosure
This PR was created by an AI agent (OpenHands) on behalf of @neubig.