### PR TITLE
fix(integrations): prefer Linear MCP OAuth while keeping bearer fallback

### DIFF
--- a/integrations/catalog/linear.json
+++ b/integrations/catalog/linear.json
@@ -12,6 +12,34 @@
   "popularityRank": 86,
   "connectionOptions": [
     {
+      "id": "oauth",
+      "provider": "mcp",
+      "auth": {
+        "strategy": "oauth2",
+        "oauth": {
+          "authorizationUrl": "https://mcp.linear.app/authorize",
+          "tokenUrl": "https://mcp.linear.app/token",
+          "registrationUrl": "https://mcp.linear.app/register",
+          "scopes": [
+            "read",
+            "write"
+          ],
+          "pkce": true,
+          "clientAuthentication": "none",
+          "additionalAuthorizationParams": {
+            "resource": "https://mcp.linear.app/mcp"
+          },
+          "additionalTokenParams": {
+            "resource": "https://mcp.linear.app/mcp"
+          }
+        }
+      },
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.linear.app/mcp"
+      }
+    },
+    {
       "id": "api-key",
       "provider": "mcp",
       "transport": {
@@ -36,5 +64,5 @@
     "tasks",
     "tickets"
   ],
-  "installHint": "Authenticate with a Linear API key (Linear → Settings → Security & access) — sent as a Bearer token. Optional when the endpoint accepts your OAuth session."
+  "installHint": "Prefer the OAuth MCP connection for Linear. The MCP server supports OAuth 2.1 with dynamic client registration at mcp.linear.app; a bearer-token MCP option remains available for API-key or existing OAuth-token workflows."
 }


### PR DESCRIPTION
## Summary
Linear's MCP server supports OAuth, and the catalog currently exposes only the bearer/API-key MCP option. Add a first-class OAuth MCP connection option for Linear and keep the existing bearer-token MCP option as a fallback.

Linear's MCP metadata advertises:
- protected resource: `https://mcp.linear.app/mcp`
- authorization server: `https://mcp.linear.app`
- authorization endpoint: `https://mcp.linear.app/authorize`
- token endpoint: `https://mcp.linear.app/token`
- dynamic registration endpoint: `https://mcp.linear.app/register`
- scopes: `read`, `write`
- PKCE S256 / token endpoint auth method `none`

## Why
The 0.7.0 cleanup removed Linear's HTTP/OAuth entry because Linear's API is GraphQL and the new HTTP catalog contract requires OpenAPI for REST tool indexing. That was correct for HTTP, but incomplete for Linear: OAuth is available on the remote MCP server itself. The right catalog shape is therefore MCP OAuth first, bearer token MCP second.

## Validation
- `npm run build:integrations`
- `uv run pytest tests/test_catalog_schema.py tests/test_catalogs.py tests/test_integration_catalog_in_sync.py -q` — 95 passed

## AI disclosure
This PR was created by an AI agent (OpenHands) on behalf of @neubig.