### PR TITLE
fix(catalog): favor Notion OAuth connection option

### DIFF
--- a/integrations/catalog/notion.json
+++ b/integrations/catalog/notion.json
@@ -11,6 +11,22 @@
   "popularityRank": 82,
   "connectionOptions": [
     {
+      "id": "oauth",
+      "provider": "http",
+      "auth": {
+        "strategy": "oauth2",
+        "oauth": {
+          "authorizationUrl": "https://api.notion.com/v1/oauth/authorize",
+          "tokenUrl": "https://api.notion.com/v1/oauth/token",
+          "scopes": []
+        }
+      },
+      "http": {
+        "apiBaseUrl": "https://api.notion.com",
+        "openApiUrl": "https://developers.notion.com/openapi.json"
+      }
+    },
+    {
       "id": "api",
       "provider": "mcp",
       "transport": {
@@ -35,22 +51,6 @@
       },
       "auth": {
         "strategy": "api_key"
-      }
-    },
-    {
-      "id": "oauth",
-      "provider": "http",
-      "auth": {
-        "strategy": "oauth2",
-        "oauth": {
-          "authorizationUrl": "https://api.notion.com/v1/oauth/authorize",
-          "tokenUrl": "https://api.notion.com/v1/oauth/token",
-          "scopes": []
-        }
-      },
-      "http": {
-        "apiBaseUrl": "https://api.notion.com",
-        "openApiUrl": "https://developers.notion.com/openapi.json"
       }
     }
   ],


### PR DESCRIPTION
## Problem

In `integrations-hub`, Slack and Linear surface as OAuth connectors, but Notion does not — it shows as an `api_key` connector.

## Root cause

`integrations/catalog/notion.json` listed two connection options with the `api` (api_key / stdio MCP) option **first** and the `oauth` (OAuth2 / HTTP) option **second**:

```json
"connectionOptions": [
  { "id": "api",   "auth": { "strategy": "api_key" } },  // first → used
  { "id": "oauth", "auth": { "strategy": "oauth2" } }    // second → ignored
]
```

`integrations-hub` builds each visible connector from **only the first** connection option (`integration.connectionOptions[0]` in `src/lib/integrations/integration-catalog.ts`), so Notion surfaced as an `api_key` connector and its OAuth option was silently dropped. Slack and Linear both list `oauth` first, which is why they show as OAuth connectors.

## Fix

Reorder `notion.json` so the `oauth` option comes first (favored) and the `api_key` stdio MCP option remains as a fallback — matching the Slack/Linear convention. Both options are retained; only the order changes.

## Verification

- JSON validated; option order is now `["oauth", "api"]`, first auth strategy `oauth2`.
- Ran the catalog test suite: **95 passed** (`test_catalogs.py`, `test_catalog_schema.py`, `test_integration_catalog_in_sync.py`).
- No test asserts the previous ordering.

This is a catalog-data-only change (no code, no schema change). Once merged, release-please will fold it into the queued `0.8.0` release PR (#377).

_This PR was created by an AI agent (OpenHands) on behalf of @neubig._