### PR TITLE
feat(integrations): add Superhuman Mail MCP catalog entry

### DIFF
--- a/integrations/catalog-index.js
+++ b/integrations/catalog-index.js
@@ -73,7 +73,8 @@ import entry67 from "./catalog/playwright.json" with { type: "json" };
 import entry68 from "./catalog/redis.json" with { type: "json" };
 import entry69 from "./catalog/resend.json" with { type: "json" };
 import entry70 from "./catalog/sequential-thinking.json" with { type: "json" };
-import entry71 from "./catalog/time.json" with { type: "json" };
+import entry71 from "./catalog/superhuman-mail.json" with { type: "json" };
+import entry72 from "./catalog/time.json" with { type: "json" };
 
 export const INTEGRATION_CATALOG_ENTRIES = [
   entry0,
@@ -148,4 +149,5 @@ export const INTEGRATION_CATALOG_ENTRIES = [
   entry69,
   entry70,
   entry71,
+  entry72,
 ];

--- a/integrations/catalog/superhuman-mail.json
+++ b/integrations/catalog/superhuman-mail.json
@@ -18,7 +18,10 @@
         "url": "https://mcp.mail.superhuman.com/mcp"
       },
       "auth": {
-        "strategy": "oauth2"
+        "strategy": "oauth2",
+        "oauth": {
+          "clientAuthentication": "none"
+        }
       }
     }
   ],

--- a/integrations/catalog/superhuman-mail.json
+++ b/integrations/catalog/superhuman-mail.json
@@ -1,0 +1,33 @@
+{
+  "id": "superhuman-mail",
+  "name": "Superhuman Mail",
+  "description": "Search, read, draft, and send email via Superhuman's hosted MCP server.",
+  "categories": [
+    "Communication",
+    "Email"
+  ],
+  "appUrl": "https://superhuman.com",
+  "docsUrl": "https://github.com/superhuman/mcp-mail",
+  "notes": "OAuth is handled by the Superhuman MCP server itself (mcp-remote). No client credentials required.",
+  "connectionOptions": [
+    {
+      "id": "oauth",
+      "provider": "mcp",
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.mail.superhuman.com/mcp"
+      },
+      "auth": {
+        "strategy": "oauth2"
+      }
+    }
+  ],
+  "iconBg": "#FF5C28",
+  "logoUrl": "https://cdn.simpleicons.org/superhuman/FFFFFF",
+  "keywords": [
+    "email",
+    "mail",
+    "superhuman",
+    "inbox"
+  ]
+}


### PR DESCRIPTION
## Summary

Add Superhuman Mail to the integrations catalog as a hosted streamable HTTP MCP server at `https://mcp.mail.superhuman.com/mcp` using OAuth2 with no client secret required.

## Changes

- Add `integrations/catalog/superhuman-mail.json` with Superhuman metadata, `shttp` transport, and OAuth2 `clientAuthentication: "none"`.
- Rebuild `integrations/catalog-index.js` so the catalog exports the new entry.

## Cross-Repo Context

- Agent-server/SDK OAuth runtime support: [software-agent-sdk PR #3964](https://github.com/OpenHands/software-agent-sdk/pull/3964)
- Canvas install/edit support: [agent-canvas PR #1583](https://github.com/OpenHands/agent-canvas/pull/1583)

## Testing

- Schema validation passes for the new catalog entry.
- `catalog-index.js` rebuilt successfully.
- GitHub checks are passing on this PR.
