### PR TITLE
docs: document AUTOMATION_MODEL profile selection for custom scripts

### DIFF
--- a/skills/openhands-automation/references/custom-automation.md
+++ b/skills/openhands-automation/references/custom-automation.md
@@ -272,6 +272,26 @@ with OpenHandsCloudWorkspace(
 # OpenHandsCloudWorkspace.__exit__ fires the completion callback here.
 ```
 
+### Selecting an LLM profile
+
+The automation service injects an `AUTOMATION_MODEL` environment variable holding the **LLM profile name** the automation should run with. This is the profile a user selects when editing the automation, or — when none is selected — a snapshot of the user's active profile taken when the automation was created. To honor it on every run, read `AUTOMATION_MODEL` and pass it to `workspace.get_llm(profile_name=...)`:
+
+```python
+# AUTOMATION_MODEL is the selected profile name (absent when none was chosen).
+model_profile = os.environ.get("AUTOMATION_MODEL") or None
+try:
+    llm = workspace.get_llm(profile_name=model_profile)
+except FileNotFoundError:
+    # The profile was renamed or deleted after the automation was created;
+    # fall back to the user's default LLM rather than failing the run.
+    if not model_profile:
+        raise
+    print(f"profile {model_profile!r} not found; falling back to default profile")
+    llm = workspace.get_llm()
+```
+
+Calling `workspace.get_llm()` with no `profile_name` always uses the user's default LLM. The built-in prompt and plugin presets already follow the pattern above; custom scripts should too so the selected profile is honored regardless of trigger type or execution backend.
+
 ### Conversation Persistence
 
 Conversations started during a run remain accessible in the OpenHands UI after the run completes — users can view the history and continue interacting. By default, `Conversation` does not delete the conversation on close:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

The built-in prompt/plugin presets already honor the per-automation LLM profile via the `AUTOMATION_MODEL` env var injected by the dispatcher, but **custom** automation scripts only honor it if they explicitly read that variable and pass it to `get_llm(profile_name=...)`. That expectation was undocumented, so a custom script could silently ignore the profile a user selected in Agent Canvas.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Add a "Selecting an LLM profile" section to `skills/openhands-automation/references/custom-automation.md` documenting the `AUTOMATION_MODEL` env var and the `get_llm(profile_name=os.environ.get("AUTOMATION_MODEL") or None)` pattern, including the `FileNotFoundError` fallback for renamed/deleted profiles and the "no profile → default LLM" behavior.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves https://github.com/OpenHands/automation/issues/153

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

- Read `skills/openhands-automation/references/custom-automation.md` → new "Selecting an LLM profile" section renders and reads correctly.
- Confirm the code pattern matches the presets it references: `openhands/automation/presets/{prompt,plugin}/sdk_main.py` (`model_profile = os.environ.get("AUTOMATION_MODEL") or None` + `workspace.get_llm(profile_name=model_profile)` with `FileNotFoundError` fallback).

