### PR TITLE
feat(integrations): define multi-account connection resource model

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -18,6 +18,25 @@ integrations so clients can consume one source of truth.
 Each integration carries its OAuth/MCP connection data directly. Do not add a
 separate provider catalog or per-language provider data.
 
+Connection options may also carry an optional `connectionModel`. This metadata
+lets consumers distinguish the authenticated principal from the external
+resource the credential can reach:
+
+- `principalType` describes who or what authenticated.
+- `credentialScope` describes the provider boundary enforced by the credential.
+- `resourceType` and `resourceCardinality` describe whether the grant represents
+  one workspace/site/tenant or can enumerate several.
+- `selectionMode` tells clients whether the resource is known during auth,
+  selected immediately after auth, or supplied at runtime.
+- `identityMapping` contains constrained dot paths for identity values returned
+  by OAuth, access-token claims, or a provider identity endpoint.
+- `resourceDiscovery` describes a read-only endpoint used to enumerate resources
+  when one grant covers several of them.
+
+These fields are descriptive; they never broaden the scopes enforced by the
+provider credential. Consumers must not claim resource-level isolation when a
+provider token is only account- or tenant-scoped.
+
 Consumers should use the read functions exported by the package:
 
 ```js

--- a/integrations/catalog.schema.json
+++ b/integrations/catalog.schema.json
@@ -91,6 +91,72 @@
         }
       }
     },
+    "identityPath": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]+(?:\\.[A-Za-z0-9_-]+)*$",
+      "minLength": 1
+    },
+    "identityMapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source"],
+      "properties": {
+        "source": {
+          "enum": ["oauth_token_response", "access_token_claims", "identity_api"]
+        },
+        "endpoint": { "type": "string", "pattern": "^https://", "minLength": 8 },
+        "externalPrincipalIdPath": { "$ref": "#/$defs/identityPath" },
+        "externalTenantIdPath": { "$ref": "#/$defs/identityPath" },
+        "externalResourceIdPath": { "$ref": "#/$defs/identityPath" },
+        "resourceNamePath": { "$ref": "#/$defs/identityPath" },
+        "resourceUrlPath": { "$ref": "#/$defs/identityPath" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "source": { "const": "identity_api" } } },
+          "then": { "required": ["endpoint"] },
+          "else": { "not": { "required": ["endpoint"] } }
+        }
+      ]
+    },
+    "resourceDiscovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["endpoint", "externalResourceIdPath"],
+      "properties": {
+        "endpoint": { "type": "string", "pattern": "^https://", "minLength": 8 },
+        "itemsPath": { "$ref": "#/$defs/identityPath" },
+        "externalResourceIdPath": { "$ref": "#/$defs/identityPath" },
+        "resourceNamePath": { "$ref": "#/$defs/identityPath" },
+        "resourceUrlPath": { "$ref": "#/$defs/identityPath" }
+      }
+    },
+    "connectionModel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "principalType",
+        "credentialScope",
+        "resourceType",
+        "resourceCardinality",
+        "selectionMode"
+      ],
+      "properties": {
+        "principalType": { "enum": ["user", "bot", "service_account", "application"] },
+        "credentialScope": { "enum": ["account", "tenant", "organization", "resource"] },
+        "resourceType": { "type": "string", "minLength": 1 },
+        "resourceCardinality": { "enum": ["one", "many"] },
+        "selectionMode": { "enum": ["automatic", "post_auth", "runtime"] },
+        "identityMapping": { "$ref": "#/$defs/identityMapping" },
+        "resourceDiscovery": { "$ref": "#/$defs/resourceDiscovery" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "selectionMode": { "const": "post_auth" } } },
+          "then": { "required": ["resourceDiscovery"] }
+        }
+      ]
+    },
     "authConfig": {
       "type": "object",
       "additionalProperties": false,
@@ -186,7 +252,8 @@
         "provider": { "enum": ["mcp", "http"] },
         "transport": { "$ref": "#/$defs/transport" },
         "http": { "$ref": "#/$defs/httpConfig" },
-        "auth": { "$ref": "#/$defs/authConfig" }
+        "auth": { "$ref": "#/$defs/authConfig" },
+        "connectionModel": { "$ref": "#/$defs/connectionModel" }
       },
       "allOf": [
         {

--- a/integrations/catalog/atlassian.json
+++ b/integrations/catalog/atlassian.json
@@ -24,6 +24,19 @@
     {
       "id": "oauth",
       "provider": "mcp",
+      "connectionModel": {
+        "principalType": "user",
+        "credentialScope": "account",
+        "resourceType": "site",
+        "resourceCardinality": "many",
+        "selectionMode": "post_auth",
+        "resourceDiscovery": {
+          "endpoint": "https://api.atlassian.com/oauth/token/accessible-resources",
+          "externalResourceIdPath": "id",
+          "resourceNamePath": "name",
+          "resourceUrlPath": "url"
+        }
+      },
       "transport": {
         "kind": "shttp",
         "url": "https://mcp.atlassian.com/v1/mcp"

--- a/integrations/catalog/github.json
+++ b/integrations/catalog/github.json
@@ -14,6 +14,26 @@
     {
       "id": "oauth",
       "provider": "mcp",
+      "connectionModel": {
+        "principalType": "user",
+        "credentialScope": "account",
+        "resourceType": "organization",
+        "resourceCardinality": "many",
+        "selectionMode": "post_auth",
+        "identityMapping": {
+          "source": "identity_api",
+          "endpoint": "https://api.github.com/user",
+          "externalPrincipalIdPath": "id",
+          "resourceNamePath": "login",
+          "resourceUrlPath": "html_url"
+        },
+        "resourceDiscovery": {
+          "endpoint": "https://api.github.com/user/orgs",
+          "externalResourceIdPath": "id",
+          "resourceNamePath": "login",
+          "resourceUrlPath": "html_url"
+        }
+      },
       "auth": {
         "strategy": "oauth2",
         "oauth": {

--- a/integrations/catalog/microsoft-outlook.json
+++ b/integrations/catalog/microsoft-outlook.json
@@ -14,6 +14,19 @@
     {
       "id": "oauth",
       "provider": "http",
+      "connectionModel": {
+        "principalType": "user",
+        "credentialScope": "tenant",
+        "resourceType": "tenant",
+        "resourceCardinality": "one",
+        "selectionMode": "automatic",
+        "identityMapping": {
+          "source": "access_token_claims",
+          "externalPrincipalIdPath": "oid",
+          "externalTenantIdPath": "tid",
+          "externalResourceIdPath": "tid"
+        }
+      },
       "auth": {
         "strategy": "oauth2",
         "oauth": {

--- a/integrations/catalog/microsoft-teams.json
+++ b/integrations/catalog/microsoft-teams.json
@@ -14,6 +14,19 @@
     {
       "id": "oauth",
       "provider": "http",
+      "connectionModel": {
+        "principalType": "user",
+        "credentialScope": "tenant",
+        "resourceType": "tenant",
+        "resourceCardinality": "one",
+        "selectionMode": "automatic",
+        "identityMapping": {
+          "source": "access_token_claims",
+          "externalPrincipalIdPath": "oid",
+          "externalTenantIdPath": "tid",
+          "externalResourceIdPath": "tid"
+        }
+      },
       "auth": {
         "strategy": "oauth2",
         "oauth": {

--- a/integrations/catalog/notion.json
+++ b/integrations/catalog/notion.json
@@ -13,6 +13,19 @@
     {
       "id": "oauth",
       "provider": "http",
+      "connectionModel": {
+        "principalType": "user",
+        "credentialScope": "resource",
+        "resourceType": "workspace",
+        "resourceCardinality": "one",
+        "selectionMode": "automatic",
+        "identityMapping": {
+          "source": "oauth_token_response",
+          "externalPrincipalIdPath": "owner.user.id",
+          "externalResourceIdPath": "workspace_id",
+          "resourceNamePath": "workspace_name"
+        }
+      },
       "auth": {
         "strategy": "oauth2",
         "oauth": {

--- a/integrations/catalog/onedrive.json
+++ b/integrations/catalog/onedrive.json
@@ -14,6 +14,19 @@
     {
       "id": "oauth",
       "provider": "http",
+      "connectionModel": {
+        "principalType": "user",
+        "credentialScope": "tenant",
+        "resourceType": "tenant",
+        "resourceCardinality": "one",
+        "selectionMode": "automatic",
+        "identityMapping": {
+          "source": "access_token_claims",
+          "externalPrincipalIdPath": "oid",
+          "externalTenantIdPath": "tid",
+          "externalResourceIdPath": "tid"
+        }
+      },
       "auth": {
         "strategy": "oauth2",
         "oauth": {

--- a/integrations/catalog/sharepoint.json
+++ b/integrations/catalog/sharepoint.json
@@ -14,6 +14,19 @@
     {
       "id": "oauth",
       "provider": "http",
+      "connectionModel": {
+        "principalType": "user",
+        "credentialScope": "tenant",
+        "resourceType": "tenant",
+        "resourceCardinality": "one",
+        "selectionMode": "automatic",
+        "identityMapping": {
+          "source": "access_token_claims",
+          "externalPrincipalIdPath": "oid",
+          "externalTenantIdPath": "tid",
+          "externalResourceIdPath": "tid"
+        }
+      },
       "auth": {
         "strategy": "oauth2",
         "oauth": {

--- a/integrations/catalog/slack.json
+++ b/integrations/catalog/slack.json
@@ -14,6 +14,20 @@
     {
       "id": "oauth",
       "provider": "mcp",
+      "connectionModel": {
+        "principalType": "user",
+        "credentialScope": "resource",
+        "resourceType": "workspace",
+        "resourceCardinality": "one",
+        "selectionMode": "automatic",
+        "identityMapping": {
+          "source": "oauth_token_response",
+          "externalPrincipalIdPath": "authed_user.id",
+          "externalTenantIdPath": "enterprise.id",
+          "externalResourceIdPath": "team.id",
+          "resourceNamePath": "team.name"
+        }
+      },
       "auth": {
         "strategy": "oauth2",
         "oauth": {

--- a/integrations/index.d.ts
+++ b/integrations/index.d.ts
@@ -95,12 +95,58 @@ export interface IntegrationHttpConfig {
   openApiUrl?: string;
 }
 
+export type IntegrationPrincipalType =
+  | "user"
+  | "bot"
+  | "service_account"
+  | "application";
+
+export type IntegrationCredentialScope =
+  | "account"
+  | "tenant"
+  | "organization"
+  | "resource";
+
+export type IntegrationIdentitySource =
+  | "oauth_token_response"
+  | "access_token_claims"
+  | "identity_api";
+
+export interface IntegrationIdentityMapping {
+  source: IntegrationIdentitySource;
+  endpoint?: string;
+  externalPrincipalIdPath?: string;
+  externalTenantIdPath?: string;
+  externalResourceIdPath?: string;
+  resourceNamePath?: string;
+  resourceUrlPath?: string;
+}
+
+export interface IntegrationResourceDiscovery {
+  endpoint: string;
+  itemsPath?: string;
+  externalResourceIdPath: string;
+  resourceNamePath?: string;
+  resourceUrlPath?: string;
+}
+
+export interface IntegrationConnectionModel {
+  principalType: IntegrationPrincipalType;
+  credentialScope: IntegrationCredentialScope;
+  resourceType: string;
+  resourceCardinality: "one" | "many";
+  selectionMode: "automatic" | "post_auth" | "runtime";
+  identityMapping?: IntegrationIdentityMapping;
+  resourceDiscovery?: IntegrationResourceDiscovery;
+}
+
 export interface IntegrationConnectionOption {
   id: "oauth" | "api" | "none" | string;
   provider: IntegrationProvider;
   transport?: IntegrationTransport;
   http?: IntegrationHttpConfig;
   auth: IntegrationAuthConfig;
+  connectionModel?: IntegrationConnectionModel;
 }
 
 

--- a/tests/test_catalog_schema.py
+++ b/tests/test_catalog_schema.py
@@ -45,3 +45,30 @@ def test_catalog_entry_validates_against_schema(entry_path: Path) -> None:
 def test_schema_file_is_valid_draft_2020_12() -> None:
     """The schema itself must be a valid Draft 2020-12 document."""
     Draft202012Validator.check_schema(_SCHEMA)
+
+
+@pytest.mark.parametrize(
+    ("entry_id", "resource_type", "cardinality", "selection_mode"),
+    [
+        ("slack", "workspace", "one", "automatic"),
+        ("notion", "workspace", "one", "automatic"),
+        ("microsoft-teams", "tenant", "one", "automatic"),
+        ("atlassian", "site", "many", "post_auth"),
+        ("github", "organization", "many", "post_auth"),
+    ],
+)
+def test_oauth_connection_model_examples(
+    entry_id: str,
+    resource_type: str,
+    cardinality: str,
+    selection_mode: str,
+) -> None:
+    entry = json.loads((CATALOG_DIR / f"{entry_id}.json").read_text())
+    oauth_option = next(
+        option for option in entry["connectionOptions"] if option["id"] == "oauth"
+    )
+    model = oauth_option["connectionModel"]
+
+    assert model["resourceType"] == resource_type
+    assert model["resourceCardinality"] == cardinality
+    assert model["selectionMode"] == selection_mode


### PR DESCRIPTION
## Summary

- add an optional provider-neutral `connectionModel` contract to integration connection options
- describe principal, credential scope, resource cardinality, identity extraction, and read-only resource discovery
- annotate Slack, Notion, Microsoft Graph, Atlassian, and GitHub with representative models
- document the isolation boundary: resource metadata cannot narrow a broader provider credential

## Validation

- `npm run build`
- `uv run --group test pytest -q` (447 passed)
- focused catalog/schema/version suite (97 passed)

Closes #398.
Blocks OpenHands/integrations-hub#82. The Integrations Hub PR must remain blocked until this change is released in both the npm and Python `openhands-extensions` packages.
