### PR TITLE
fix(integrations): use Datadog MCP header names

### DIFF
--- a/integrations/catalog/datadog.json
+++ b/integrations/catalog/datadog.json
@@ -7,7 +7,7 @@
     "Operations"
   ],
   "appUrl": "https://www.datadoghq.com",
-  "docsUrl": "https://docs.datadoghq.com/bits_ai/mcp_server/setup/",
+  "docsUrl": "https://docs.datadoghq.com/mcp_server/setup/",
   "notes": "Uses Datadog's official hosted MCP server. The MCP endpoint host is site-specific: use https://mcp.<site>.datadoghq.com/v1/mcp for your Datadog site (e.g. mcp.us5.datadoghq.com for US5). The default URL below targets US1 and can be edited in the install dialog.",
   "popularityRank": 35,
   "installHint": "The Datadog MCP URL is site-specific. Edit the URL to https://mcp.<site>.datadoghq.com/v1/mcp for your Datadog site (for example https://mcp.us5.datadoghq.com/v1/mcp for US5, https://mcp.eu.datadoghq.com/v1/mcp for EU). Find your site at Organization Settings → Site in Datadog.",
@@ -43,7 +43,7 @@
         "urlEditable": true,
         "headerFields": [
           {
-            "key": "DD-API-KEY",
+            "key": "DD_API_KEY",
             "label": "Datadog API key",
             "type": "password",
             "required": true,
@@ -51,7 +51,7 @@
             "helperText": "Created in Datadog under Organization Settings → API Keys. Used to authenticate to the Datadog MCP server. See the [setup docs](https://docs.datadoghq.com/mcp_server/setup/?tab=other#authentication)."
           },
           {
-            "key": "DD-APPLICATION-KEY",
+            "key": "DD_APPLICATION_KEY",
             "label": "Datadog Application key",
             "type": "password",
             "required": true,

--- a/integrations/index.d.ts
+++ b/integrations/index.d.ts
@@ -17,7 +17,7 @@ export type IntegrationTransport =
       apiKeyOptional?: boolean;
       /**
        * Named request headers the user must supply (e.g. Datadog's
-       * `DD-API-KEY` / `DD-APPLICATION-KEY`). Values are sent verbatim as
+       * `DD_API_KEY` / `DD_APPLICATION_KEY`). Values are sent verbatim as
        * headers on every MCP request. The direct analog of stdio's
        * `envFields`: each entry renders one input in the install modal,
        * `type: "password"` entries are secret-saved by default, and

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -81,7 +81,7 @@ def test_remote_no_auth_mcp_entries_are_intentionally_public():
             transport = option.get("transport", {})
             # An option with `headerFields` still requires the user to supply
             # credentials (just via named headers, e.g. Datadog's
-            # DD-API-KEY/DD-APPLICATION-KEY), so it is NOT "public/no-auth".
+            # DD_API_KEY/DD_APPLICATION_KEY), so it is NOT "public/no-auth".
             has_header_credentials = bool(transport.get("headerFields"))
             if (
                 option["provider"] == "mcp"
@@ -93,6 +93,21 @@ def test_remote_no_auth_mcp_entries_are_intentionally_public():
                 assert transport["kind"] == "shttp"
 
     assert actual == public_remote_mcp_ids
+
+
+def test_datadog_mcp_uses_documented_api_key_headers():
+    datadog = next(
+        entry
+        for entry in load_catalog_entries("integrations/catalog")
+        if entry["id"] == "datadog"
+    )
+    api_option = next(
+        option for option in datadog["connectionOptions"] if option["id"] == "api"
+    )
+
+    assert [
+        field["key"] for field in api_option["transport"]["headerFields"]
+    ] == ["DD_API_KEY", "DD_APPLICATION_KEY"]
 
 
 def test_credential_fields_have_helper_text_and_link():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

I have confirmed that this works in agent canvas.

<img width="591" height="388" alt="Screenshot 2026-07-13 at 9 39 21 PM" src="https://github.com/user-attachments/assets/93efa828-b1ff-4954-8f22-bfa169cea1dd" />

- [x] A human has tested these changes.

---

## Why

The Datadog integration catalog used the REST API-style `DD-API-KEY` and
`DD-APPLICATION-KEY` request headers for the hosted MCP server. Datadog's MCP
documentation requires `DD_API_KEY` and `DD_APPLICATION_KEY`, so clients that
send the catalog fields verbatim receive a 403 response.

## Summary

- Use Datadog's documented hosted MCP API-key header names.
- Point the integration at the current Datadog MCP setup documentation.
- Add a regression test for the Datadog MCP header contract.

## Issue Number

N/A

## How to Test

```bash
npm run build:integrations
python scripts/sync_extensions.py --check
uv run pytest -q
```

The full test suite passes: 461 tests.

## Video/Screenshots

N/A - catalog metadata only.

## Notes

Datadog's ordinary REST API continues to use the hyphenated headers. This
change is limited to the hosted MCP integration metadata.

## Tracking

Related to #363.

## Tracking issue

Closes #411.

## Live evidence

Validated the hosted Datadog MCP production endpoint on 2026-07-14 UTC using the corrected underscore header names. Credentials were sent only as redacted request headers.

- Endpoint: `https://mcp.us5.datadoghq.com/v1/mcp`
- JSON-RPC `initialize` returned HTTP 200, protocol `2025-06-18`, server `datadog-mcp` version `1.0.0`, and tools capability.
- A session-scoped `tools/list` returned HTTP 200 with 3 tools: `get_change_stories`, `list_datadog_skills`, and `load_datadog_skill`.
- The attached Agent Canvas screenshot and checked human-testing attestation remain the UI-path evidence.
- Repository validation: `npm run build:integrations`, `python scripts/sync_extensions.py --check`, and `uv run pytest -q` (461 tests).