### PR TITLE
feat(integrations): add Atlassian Rovo MCP server (OAuth 2.1)

### DIFF
--- a/integrations/catalog-index.js
+++ b/integrations/catalog-index.js
@@ -48,34 +48,35 @@ import entry42 from "./catalog/google-drive.json" with { type: "json" };
 import entry43 from "./catalog/figma.json" with { type: "json" };
 import entry44 from "./catalog/google-docs.json" with { type: "json" };
 import entry45 from "./catalog/apify.json" with { type: "json" };
-import entry46 from "./catalog/brave-search.json" with { type: "json" };
-import entry47 from "./catalog/browser-mcp.json" with { type: "json" };
-import entry48 from "./catalog/clickhouse.json" with { type: "json" };
-import entry49 from "./catalog/cloudflare-bindings.json" with { type: "json" };
-import entry50 from "./catalog/cloudflare-browser-rendering.json" with { type: "json" };
-import entry51 from "./catalog/cloudflare-builds.json" with { type: "json" };
-import entry52 from "./catalog/cloudflare-docs.json" with { type: "json" };
-import entry53 from "./catalog/cloudflare-observability.json" with { type: "json" };
-import entry54 from "./catalog/deepwiki.json" with { type: "json" };
-import entry55 from "./catalog/everything.json" with { type: "json" };
-import entry56 from "./catalog/exa.json" with { type: "json" };
-import entry57 from "./catalog/fetch.json" with { type: "json" };
-import entry58 from "./catalog/filesystem.json" with { type: "json" };
-import entry59 from "./catalog/firecrawl.json" with { type: "json" };
-import entry60 from "./catalog/git.json" with { type: "json" };
-import entry61 from "./catalog/huggingface.json" with { type: "json" };
-import entry62 from "./catalog/kagi.json" with { type: "json" };
-import entry63 from "./catalog/memory.json" with { type: "json" };
-import entry64 from "./catalog/mongodb.json" with { type: "json" };
-import entry65 from "./catalog/neon.json" with { type: "json" };
-import entry66 from "./catalog/obsidian.json" with { type: "json" };
-import entry67 from "./catalog/paypal.json" with { type: "json" };
-import entry68 from "./catalog/playwright.json" with { type: "json" };
-import entry69 from "./catalog/redis.json" with { type: "json" };
-import entry70 from "./catalog/resend.json" with { type: "json" };
-import entry71 from "./catalog/sequential-thinking.json" with { type: "json" };
-import entry72 from "./catalog/superhuman-mail.json" with { type: "json" };
-import entry73 from "./catalog/time.json" with { type: "json" };
+import entry46 from "./catalog/atlassian-rovo.json" with { type: "json" };
+import entry47 from "./catalog/brave-search.json" with { type: "json" };
+import entry48 from "./catalog/browser-mcp.json" with { type: "json" };
+import entry49 from "./catalog/clickhouse.json" with { type: "json" };
+import entry50 from "./catalog/cloudflare-bindings.json" with { type: "json" };
+import entry51 from "./catalog/cloudflare-browser-rendering.json" with { type: "json" };
+import entry52 from "./catalog/cloudflare-builds.json" with { type: "json" };
+import entry53 from "./catalog/cloudflare-docs.json" with { type: "json" };
+import entry54 from "./catalog/cloudflare-observability.json" with { type: "json" };
+import entry55 from "./catalog/deepwiki.json" with { type: "json" };
+import entry56 from "./catalog/everything.json" with { type: "json" };
+import entry57 from "./catalog/exa.json" with { type: "json" };
+import entry58 from "./catalog/fetch.json" with { type: "json" };
+import entry59 from "./catalog/filesystem.json" with { type: "json" };
+import entry60 from "./catalog/firecrawl.json" with { type: "json" };
+import entry61 from "./catalog/git.json" with { type: "json" };
+import entry62 from "./catalog/huggingface.json" with { type: "json" };
+import entry63 from "./catalog/kagi.json" with { type: "json" };
+import entry64 from "./catalog/memory.json" with { type: "json" };
+import entry65 from "./catalog/mongodb.json" with { type: "json" };
+import entry66 from "./catalog/neon.json" with { type: "json" };
+import entry67 from "./catalog/obsidian.json" with { type: "json" };
+import entry68 from "./catalog/paypal.json" with { type: "json" };
+import entry69 from "./catalog/playwright.json" with { type: "json" };
+import entry70 from "./catalog/redis.json" with { type: "json" };
+import entry71 from "./catalog/resend.json" with { type: "json" };
+import entry72 from "./catalog/sequential-thinking.json" with { type: "json" };
+import entry73 from "./catalog/superhuman-mail.json" with { type: "json" };
+import entry74 from "./catalog/time.json" with { type: "json" };
 
 export const INTEGRATION_CATALOG_ENTRIES = [
   entry0,
@@ -152,4 +153,5 @@ export const INTEGRATION_CATALOG_ENTRIES = [
   entry71,
   entry72,
   entry73,
+  entry74,
 ];

--- a/integrations/catalog/atlassian-rovo.json
+++ b/integrations/catalog/atlassian-rovo.json
@@ -1,0 +1,44 @@
+{
+  "id": "atlassian-rovo",
+  "name": "Atlassian Rovo",
+  "description": "Search, create, and update Jira issues, Confluence pages, Bitbucket repos, and Jira Service Management tickets - all through Atlassian's official hosted MCP server, powered by your Teamwork Graph.",
+  "categories": [
+    "Project management",
+    "Documentation",
+    "Engineering"
+  ],
+  "appUrl": "https://www.atlassian.com/rovo",
+  "docsUrl": "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/",
+  "notes": "OAuth 2.1 is handled entirely by the Atlassian Rovo MCP server. No client credentials required - sign in with your Atlassian account when the authentication flow starts.",
+  "iconBg": "#0052CC",
+  "logoUrl": "https://cdn.simpleicons.org/atlassian/FFFFFF",
+  "keywords": [
+    "atlassian",
+    "rovo",
+    "jira",
+    "confluence",
+    "bitbucket",
+    "jsm",
+    "tickets",
+    "wiki",
+    "issues",
+    "sprint",
+    "mcp"
+  ],
+  "connectionOptions": [
+    {
+      "id": "oauth",
+      "provider": "mcp",
+      "transport": {
+        "kind": "shttp",
+        "url": "https://mcp.atlassian.com/v1/mcp/authv2"
+      },
+      "auth": {
+        "strategy": "oauth2",
+        "oauth": {
+          "clientAuthentication": "none"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a catalog entry for the **official Atlassian Rovo hosted MCP server** — Atlassian's first-party, fully managed remote MCP server that surfaces Jira, Confluence, Bitbucket, and Jira Service Management through a single connection.

## What's new

- **`integrations/catalog/atlassian-rovo.json`** — new catalog entry
- **`integrations/catalog-index.js`** — regenerated via `npm run build:integrations`

## Design decisions

This entry is deliberately separate from the existing `atlassian.json` (which drives the community `uvx mcp-atlassian` stdio package with manually configured API tokens). The Rovo server is a different product with a different connection model:

| | `atlassian.json` | `atlassian-rovo.json` (this PR) |
|---|---|---|
| Server | Community `mcp-atlassian` via `uvx` (stdio) | Official Atlassian Rovo hosted MCP |
| Auth | Manual Jira/Confluence API tokens | Server-managed OAuth 2.1 |
| Transport | `stdio` | `shttp` |
| Setup required | Paste URLs + tokens | Sign in with Atlassian account |

### Why `clientAuthentication: "none"`

The Atlassian Rovo MCP server owns the entire OAuth 2.1 flow itself (identical pattern to `superhuman-mail.json`). There are no client credentials to configure — the user simply authenticates through the browser prompt that the server initiates.

## Testing

```bash
npm run build:integrations   # regenerates catalog-index.js — exits 0
python3 scripts/sync_extensions.py --check  # exits 0, no new warnings
```

## References

- MCP server URL: `https://mcp.atlassian.com/v1/mcp/authv2`
- Docs: https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/
- OAuth 2.1 details: https://support.atlassian.com/atlassian-rovo-mcp-server/docs/configuring-oauth-2-1/

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e9b7a9a7-3a68-4aaf-8923-a6b9d5cda8bd)