### PR TITLE
feat(integrations): add BountyVerdict MCP

### DIFF
--- a/integrations/catalog-index.js
+++ b/integrations/catalog-index.js
@@ -49,34 +49,35 @@ import entry43 from "./catalog/figma.json" with { type: "json" };
 import entry44 from "./catalog/google-docs.json" with { type: "json" };
 import entry45 from "./catalog/apify.json" with { type: "json" };
 import entry46 from "./catalog/atlassian-rovo.json" with { type: "json" };
-import entry47 from "./catalog/brave-search.json" with { type: "json" };
-import entry48 from "./catalog/browser-mcp.json" with { type: "json" };
-import entry49 from "./catalog/clickhouse.json" with { type: "json" };
-import entry50 from "./catalog/cloudflare-bindings.json" with { type: "json" };
-import entry51 from "./catalog/cloudflare-browser-rendering.json" with { type: "json" };
-import entry52 from "./catalog/cloudflare-builds.json" with { type: "json" };
-import entry53 from "./catalog/cloudflare-docs.json" with { type: "json" };
-import entry54 from "./catalog/cloudflare-observability.json" with { type: "json" };
-import entry55 from "./catalog/deepwiki.json" with { type: "json" };
-import entry56 from "./catalog/everything.json" with { type: "json" };
-import entry57 from "./catalog/exa.json" with { type: "json" };
-import entry58 from "./catalog/fetch.json" with { type: "json" };
-import entry59 from "./catalog/filesystem.json" with { type: "json" };
-import entry60 from "./catalog/firecrawl.json" with { type: "json" };
-import entry61 from "./catalog/git.json" with { type: "json" };
-import entry62 from "./catalog/huggingface.json" with { type: "json" };
-import entry63 from "./catalog/kagi.json" with { type: "json" };
-import entry64 from "./catalog/memory.json" with { type: "json" };
-import entry65 from "./catalog/mongodb.json" with { type: "json" };
-import entry66 from "./catalog/neon.json" with { type: "json" };
-import entry67 from "./catalog/obsidian.json" with { type: "json" };
-import entry68 from "./catalog/paypal.json" with { type: "json" };
-import entry69 from "./catalog/playwright.json" with { type: "json" };
-import entry70 from "./catalog/redis.json" with { type: "json" };
-import entry71 from "./catalog/resend.json" with { type: "json" };
-import entry72 from "./catalog/sequential-thinking.json" with { type: "json" };
-import entry73 from "./catalog/superhuman-mail.json" with { type: "json" };
-import entry74 from "./catalog/time.json" with { type: "json" };
+import entry47 from "./catalog/bountyverdict.json" with { type: "json" };
+import entry48 from "./catalog/brave-search.json" with { type: "json" };
+import entry49 from "./catalog/browser-mcp.json" with { type: "json" };
+import entry50 from "./catalog/clickhouse.json" with { type: "json" };
+import entry51 from "./catalog/cloudflare-bindings.json" with { type: "json" };
+import entry52 from "./catalog/cloudflare-browser-rendering.json" with { type: "json" };
+import entry53 from "./catalog/cloudflare-builds.json" with { type: "json" };
+import entry54 from "./catalog/cloudflare-docs.json" with { type: "json" };
+import entry55 from "./catalog/cloudflare-observability.json" with { type: "json" };
+import entry56 from "./catalog/deepwiki.json" with { type: "json" };
+import entry57 from "./catalog/everything.json" with { type: "json" };
+import entry58 from "./catalog/exa.json" with { type: "json" };
+import entry59 from "./catalog/fetch.json" with { type: "json" };
+import entry60 from "./catalog/filesystem.json" with { type: "json" };
+import entry61 from "./catalog/firecrawl.json" with { type: "json" };
+import entry62 from "./catalog/git.json" with { type: "json" };
+import entry63 from "./catalog/huggingface.json" with { type: "json" };
+import entry64 from "./catalog/kagi.json" with { type: "json" };
+import entry65 from "./catalog/memory.json" with { type: "json" };
+import entry66 from "./catalog/mongodb.json" with { type: "json" };
+import entry67 from "./catalog/neon.json" with { type: "json" };
+import entry68 from "./catalog/obsidian.json" with { type: "json" };
+import entry69 from "./catalog/paypal.json" with { type: "json" };
+import entry70 from "./catalog/playwright.json" with { type: "json" };
+import entry71 from "./catalog/redis.json" with { type: "json" };
+import entry72 from "./catalog/resend.json" with { type: "json" };
+import entry73 from "./catalog/sequential-thinking.json" with { type: "json" };
+import entry74 from "./catalog/superhuman-mail.json" with { type: "json" };
+import entry75 from "./catalog/time.json" with { type: "json" };
 
 export const INTEGRATION_CATALOG_ENTRIES = [
   entry0,
@@ -154,4 +155,5 @@ export const INTEGRATION_CATALOG_ENTRIES = [
   entry72,
   entry73,
   entry74,
+  entry75,
 ];

--- a/integrations/catalog/bountyverdict.json
+++ b/integrations/catalog/bountyverdict.json
@@ -1,0 +1,27 @@
+{
+  "id": "bountyverdict",
+  "name": "BountyVerdict Agent Decision Tools",
+  "description": "Remote, account-free MCP server for preflight decisions on public GitHub bounties, coding-agent repository instructions, GitHub Actions failures, flaky retries, and MCP tool-catalog changes. Six read-only tools return evidence-linked verdicts. A valid first unsigned call cannot charge and returns a structured selection preview plus the exact x402 USDC quote.",
+  "appUrl": "https://mimirs402.github.io/bountyverdict/",
+  "docsUrl": "https://mimirs402.github.io/bountyverdict/agents.html",
+  "keywords": [
+    "github",
+    "ci",
+    "agent-safety",
+    "mcp",
+    "x402"
+  ],
+  "connectionOptions": [
+    {
+      "id": "none",
+      "provider": "mcp",
+      "transport": {
+        "kind": "shttp",
+        "url": "https://bountyverdict-agent-production.mimirslab.workers.dev/mcp?source=openhands-integrations"
+      },
+      "auth": {
+        "strategy": "none"
+      }
+    }
+  ]
+}

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -73,7 +73,12 @@ def test_catalog_entries_have_required_fields():
 
 
 def test_remote_no_auth_mcp_entries_are_intentionally_public():
-    public_remote_mcp_ids = {"cloudflare-docs", "deepwiki", "huggingface"}
+    public_remote_mcp_ids = {
+        "bountyverdict",
+        "cloudflare-docs",
+        "deepwiki",
+        "huggingface",
+    }
 
     actual = set()
     for entry in load_catalog_entries("integrations/catalog"):


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

OpenHands users currently have no catalog-native path to connect BountyVerdict's six read-only evidence gates for public GitHub bounties, coding-agent instructions, GitHub Actions failures, flaky retries, and MCP tool-catalog changes.

## Summary

- Add the no-auth Streamable HTTP BountyVerdict MCP integration.
- Regenerate the JavaScript integration catalog index.
- Explicitly allowlist the public no-auth remote in the catalog safety test.

## Issue Number

No related issue.

## How to Test

```bash
npm run build:integrations
python scripts/sync_extensions.py --check
uv sync --group test
uv run pytest -q
```

Local result: 465 passed, 6 skipped.

## Video/Screenshots

Not applicable; this changes registry metadata only.

## Notes

The first unsigned tool call cannot charge. It returns a structured selection preview and an exact x402 Base USDC quote; payment still requires a separately authorized signed retry. No API key, secret, header, local command, or environment variable is introduced.