### PR TITLE
feat(integrations): save MCP tokens as secrets

### DIFF
--- a/integrations/catalog/linear.json
+++ b/integrations/catalog/linear.json
@@ -52,7 +52,9 @@
         "apiKeyOptional": true,
         "credentialLabel": "Linear API key",
         "credentialPlaceholder": "Paste your Linear API key",
-        "credentialHelp": "Create a personal API key (grant at least read access) under Security & access in [Linear settings](https://linear.app/settings/account/security). Sent as Authorization: Bearer <token>; optional when the endpoint accepts your OAuth session."
+        "credentialHelp": "Create a personal API key (grant at least read access) under Security & access in [Linear settings](https://linear.app/settings/account/security). Sent as Authorization: Bearer <token>; optional when the endpoint accepts your OAuth session.",
+        "credentialSecretName": "LINEAR_API_KEY",
+        "saveCredentialAsSecretByDefault": true
       }
     }
   ],

--- a/integrations/catalog/ordinal.json
+++ b/integrations/catalog/ordinal.json
@@ -22,7 +22,9 @@
         ],
         "credentialLabel": "Ordinal API key",
         "credentialPlaceholder": "Paste your Ordinal API key",
-        "credentialHelp": "API key from your Ordinal workspace settings, sent as a Bearer token in the Authorization header."
+        "credentialHelp": "API key from your Ordinal workspace settings, sent as a Bearer token in the Authorization header.",
+        "credentialSecretName": "ORDINAL_API_KEY",
+        "saveCredentialAsSecretByDefault": true
       },
       "transport": {
         "kind": "shttp",

--- a/integrations/catalog/posthog.json
+++ b/integrations/catalog/posthog.json
@@ -31,7 +31,9 @@
         "strategy": "bearer",
         "credentialLabel": "PostHog personal API key",
         "credentialPlaceholder": "Paste your PostHog personal API key",
-        "credentialHelp": "Create one under PostHog → User settings → API keys (MCP Server preset). Sent as Authorization: Bearer <token>."
+        "credentialHelp": "Create one under PostHog → User settings → API keys (MCP Server preset). Sent as Authorization: Bearer <token>.",
+        "credentialSecretName": "POSTHOG_PERSONAL_API_KEY",
+        "saveCredentialAsSecretByDefault": true
       }
     }
   ]

--- a/integrations/catalog/stripe.json
+++ b/integrations/catalog/stripe.json
@@ -22,7 +22,9 @@
         "strategy": "bearer",
         "credentialLabel": "Stripe restricted key",
         "credentialPlaceholder": "rk_live_...",
-        "credentialHelp": "Create a Stripe restricted key for MCP access and paste it here."
+        "credentialHelp": "Create a Stripe restricted key for MCP access and paste it here.",
+        "credentialSecretName": "STRIPE_RESTRICTED_KEY",
+        "saveCredentialAsSecretByDefault": true
       }
     },
     {

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -213,6 +213,23 @@ def test_daily_workflow_entries_are_locally_installable():
     assert required_env == {"SLACK_TEAM_ID", "SLACK_BOT_TOKEN"}
 
 
+def test_direct_mcp_token_credentials_can_be_saved_as_secrets():
+    for entry in load_catalog_entries("integrations/catalog"):
+        for option in entry["connectionOptions"]:
+            auth = option.get("auth", {})
+            if option.get("provider") != "mcp" or not auth.get("credentialLabel"):
+                continue
+            if auth["strategy"] not in {"api_key", "bearer"}:
+                continue
+
+            assert auth.get("credentialSecretName"), (
+                f"{entry['id']}/{option['id']}: token credential needs a secret name"
+            )
+            assert auth.get("saveCredentialAsSecretByDefault") is True, (
+                f"{entry['id']}/{option['id']}: token credential should default to secret saving"
+            )
+
+
 def test_daily_workflow_entries_state_scopes_and_setup_paths():
     """The locally installable options must state the required scopes and link a
     public setup path (OSS-5193). The OAuth options' scope lists never reach a


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Direct token-auth MCP connections should offer the same secret-saving behavior already available for GitHub and password-based transport fields.

## Summary

- Add secret names and default secret-saving metadata for Linear, Ordinal, PostHog, and Stripe MCP tokens.
- Add regression coverage requiring direct MCP token credentials to support secret saving.

## Issue Number

N/A

## How to Test

```bash
npm run build:integrations
uv run pytest -q tests/test_catalogs.py tests/test_catalog_schema.py tests/test_integration_catalog_in_sync.py
uv run python scripts/sync_extensions.py --check
```

Expected result: the integration build succeeds, all tests pass, and the sync check exits successfully.

## Video/Screenshots

Not applicable - catalog metadata and test-only changes.

## Notes

Validation completed locally with 111 relevant tests passing. The sync check emitted one unrelated warning that `plugins/issue-duplicate-checker` is not listed in a marketplace.

_This pull request was created by an AI agent (OpenHands) on behalf of the user._

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/63ce7a6f-5502-4422-bc1a-b03218eabc95)