### PR TITLE
feat(integrations): add Agent Enhancer Utilities MCP

### DIFF
--- a/integrations/catalog-index.js
+++ b/integrations/catalog-index.js
@@ -47,36 +47,37 @@ import entry41 from "./catalog/google-sheets.json" with { type: "json" };
 import entry42 from "./catalog/google-drive.json" with { type: "json" };
 import entry43 from "./catalog/figma.json" with { type: "json" };
 import entry44 from "./catalog/google-docs.json" with { type: "json" };
-import entry45 from "./catalog/apify.json" with { type: "json" };
-import entry46 from "./catalog/atlassian-rovo.json" with { type: "json" };
-import entry47 from "./catalog/brave-search.json" with { type: "json" };
-import entry48 from "./catalog/browser-mcp.json" with { type: "json" };
-import entry49 from "./catalog/clickhouse.json" with { type: "json" };
-import entry50 from "./catalog/cloudflare-bindings.json" with { type: "json" };
-import entry51 from "./catalog/cloudflare-browser-rendering.json" with { type: "json" };
-import entry52 from "./catalog/cloudflare-builds.json" with { type: "json" };
-import entry53 from "./catalog/cloudflare-docs.json" with { type: "json" };
-import entry54 from "./catalog/cloudflare-observability.json" with { type: "json" };
-import entry55 from "./catalog/deepwiki.json" with { type: "json" };
-import entry56 from "./catalog/everything.json" with { type: "json" };
-import entry57 from "./catalog/exa.json" with { type: "json" };
-import entry58 from "./catalog/fetch.json" with { type: "json" };
-import entry59 from "./catalog/filesystem.json" with { type: "json" };
-import entry60 from "./catalog/firecrawl.json" with { type: "json" };
-import entry61 from "./catalog/git.json" with { type: "json" };
-import entry62 from "./catalog/huggingface.json" with { type: "json" };
-import entry63 from "./catalog/kagi.json" with { type: "json" };
-import entry64 from "./catalog/memory.json" with { type: "json" };
-import entry65 from "./catalog/mongodb.json" with { type: "json" };
-import entry66 from "./catalog/neon.json" with { type: "json" };
-import entry67 from "./catalog/obsidian.json" with { type: "json" };
-import entry68 from "./catalog/paypal.json" with { type: "json" };
-import entry69 from "./catalog/playwright.json" with { type: "json" };
-import entry70 from "./catalog/redis.json" with { type: "json" };
-import entry71 from "./catalog/resend.json" with { type: "json" };
-import entry72 from "./catalog/sequential-thinking.json" with { type: "json" };
-import entry73 from "./catalog/superhuman-mail.json" with { type: "json" };
-import entry74 from "./catalog/time.json" with { type: "json" };
+import entry45 from "./catalog/agent-enhancer-utilities.json" with { type: "json" };
+import entry46 from "./catalog/apify.json" with { type: "json" };
+import entry47 from "./catalog/atlassian-rovo.json" with { type: "json" };
+import entry48 from "./catalog/brave-search.json" with { type: "json" };
+import entry49 from "./catalog/browser-mcp.json" with { type: "json" };
+import entry50 from "./catalog/clickhouse.json" with { type: "json" };
+import entry51 from "./catalog/cloudflare-bindings.json" with { type: "json" };
+import entry52 from "./catalog/cloudflare-browser-rendering.json" with { type: "json" };
+import entry53 from "./catalog/cloudflare-builds.json" with { type: "json" };
+import entry54 from "./catalog/cloudflare-docs.json" with { type: "json" };
+import entry55 from "./catalog/cloudflare-observability.json" with { type: "json" };
+import entry56 from "./catalog/deepwiki.json" with { type: "json" };
+import entry57 from "./catalog/everything.json" with { type: "json" };
+import entry58 from "./catalog/exa.json" with { type: "json" };
+import entry59 from "./catalog/fetch.json" with { type: "json" };
+import entry60 from "./catalog/filesystem.json" with { type: "json" };
+import entry61 from "./catalog/firecrawl.json" with { type: "json" };
+import entry62 from "./catalog/git.json" with { type: "json" };
+import entry63 from "./catalog/huggingface.json" with { type: "json" };
+import entry64 from "./catalog/kagi.json" with { type: "json" };
+import entry65 from "./catalog/memory.json" with { type: "json" };
+import entry66 from "./catalog/mongodb.json" with { type: "json" };
+import entry67 from "./catalog/neon.json" with { type: "json" };
+import entry68 from "./catalog/obsidian.json" with { type: "json" };
+import entry69 from "./catalog/paypal.json" with { type: "json" };
+import entry70 from "./catalog/playwright.json" with { type: "json" };
+import entry71 from "./catalog/redis.json" with { type: "json" };
+import entry72 from "./catalog/resend.json" with { type: "json" };
+import entry73 from "./catalog/sequential-thinking.json" with { type: "json" };
+import entry74 from "./catalog/superhuman-mail.json" with { type: "json" };
+import entry75 from "./catalog/time.json" with { type: "json" };
 
 export const INTEGRATION_CATALOG_ENTRIES = [
   entry0,
@@ -154,4 +155,5 @@ export const INTEGRATION_CATALOG_ENTRIES = [
   entry72,
   entry73,
   entry74,
+  entry75,
 ];

--- a/integrations/catalog/agent-enhancer-utilities.json
+++ b/integrations/catalog/agent-enhancer-utilities.json
@@ -1,0 +1,38 @@
+{
+  "id": "agent-enhancer-utilities",
+  "name": "Agent Enhancer Utilities",
+  "description": "Add planning, checkpoints, duplicate-action protection, recovery, and evidence tools to existing agent workflows.",
+  "categories": [
+    "AI",
+    "Developer tools"
+  ],
+  "appUrl": "https://liberated.site",
+  "docsUrl": "https://liberated.site/docs",
+  "notes": "No account or API key is required. Security: https://liberated.site/security Status: https://liberated.site/status Effectiveness: https://liberated.site/effectiveness",
+  "iconBg": "#07120F",
+  "logoUrl": "https://github.com/artiehinz/Agent-Enhancer-Utilities/releases/download/v1.5.0/agents.png",
+  "keywords": [
+    "agent",
+    "reliability",
+    "orchestration",
+    "planning",
+    "checkpoint",
+    "idempotency",
+    "recovery",
+    "evidence",
+    "mcp"
+  ],
+  "connectionOptions": [
+    {
+      "id": "none",
+      "provider": "mcp",
+      "transport": {
+        "kind": "shttp",
+        "url": "https://liberated.site/mcp?source=openhands-catalog"
+      },
+      "auth": {
+        "strategy": "none"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- [ ] A human has tested these changes.

## Summary

Adds Agent Enhancer Utilities as a no-auth Streamable HTTP integration. It provides planning, checkpoints, duplicate protection, recovery, and evidence tools for existing workflows.

The change adds one connector, its immutable icon, and the regenerated catalog index.

## Issue Number

N/A

## How to Test

```powershell
npm run build:integrations
$env:PYTHONUTF8='1'
uv run --no-group test --with pytest --with jsonschema --with requests pytest tests/test_catalog_schema.py tests/test_integration_catalog_in_sync.py -q
```

Result: 101 passed. The endpoint also passed MCP initialization. The Windows full-suite setup stopped while building `litellm`; Linux CI covers the normal full suite.

## Video/Screenshots

Metadata-only change. Demo: https://liberated.site/demo.mp4

No account, API key, or secret is required.