### PR TITLE
feat: add Brainiall TTS MCP integration

### DIFF
--- a/integrations/catalog-index.js
+++ b/integrations/catalog-index.js
@@ -49,34 +49,35 @@ import entry43 from "./catalog/figma.json" with { type: "json" };
 import entry44 from "./catalog/google-docs.json" with { type: "json" };
 import entry45 from "./catalog/apify.json" with { type: "json" };
 import entry46 from "./catalog/atlassian-rovo.json" with { type: "json" };
-import entry47 from "./catalog/brave-search.json" with { type: "json" };
-import entry48 from "./catalog/browser-mcp.json" with { type: "json" };
-import entry49 from "./catalog/clickhouse.json" with { type: "json" };
-import entry50 from "./catalog/cloudflare-bindings.json" with { type: "json" };
-import entry51 from "./catalog/cloudflare-browser-rendering.json" with { type: "json" };
-import entry52 from "./catalog/cloudflare-builds.json" with { type: "json" };
-import entry53 from "./catalog/cloudflare-docs.json" with { type: "json" };
-import entry54 from "./catalog/cloudflare-observability.json" with { type: "json" };
-import entry55 from "./catalog/deepwiki.json" with { type: "json" };
-import entry56 from "./catalog/everything.json" with { type: "json" };
-import entry57 from "./catalog/exa.json" with { type: "json" };
-import entry58 from "./catalog/fetch.json" with { type: "json" };
-import entry59 from "./catalog/filesystem.json" with { type: "json" };
-import entry60 from "./catalog/firecrawl.json" with { type: "json" };
-import entry61 from "./catalog/git.json" with { type: "json" };
-import entry62 from "./catalog/huggingface.json" with { type: "json" };
-import entry63 from "./catalog/kagi.json" with { type: "json" };
-import entry64 from "./catalog/memory.json" with { type: "json" };
-import entry65 from "./catalog/mongodb.json" with { type: "json" };
-import entry66 from "./catalog/neon.json" with { type: "json" };
-import entry67 from "./catalog/obsidian.json" with { type: "json" };
-import entry68 from "./catalog/paypal.json" with { type: "json" };
-import entry69 from "./catalog/playwright.json" with { type: "json" };
-import entry70 from "./catalog/redis.json" with { type: "json" };
-import entry71 from "./catalog/resend.json" with { type: "json" };
-import entry72 from "./catalog/sequential-thinking.json" with { type: "json" };
-import entry73 from "./catalog/superhuman-mail.json" with { type: "json" };
-import entry74 from "./catalog/time.json" with { type: "json" };
+import entry47 from "./catalog/brainiall-tts.json" with { type: "json" };
+import entry48 from "./catalog/brave-search.json" with { type: "json" };
+import entry49 from "./catalog/browser-mcp.json" with { type: "json" };
+import entry50 from "./catalog/clickhouse.json" with { type: "json" };
+import entry51 from "./catalog/cloudflare-bindings.json" with { type: "json" };
+import entry52 from "./catalog/cloudflare-browser-rendering.json" with { type: "json" };
+import entry53 from "./catalog/cloudflare-builds.json" with { type: "json" };
+import entry54 from "./catalog/cloudflare-docs.json" with { type: "json" };
+import entry55 from "./catalog/cloudflare-observability.json" with { type: "json" };
+import entry56 from "./catalog/deepwiki.json" with { type: "json" };
+import entry57 from "./catalog/everything.json" with { type: "json" };
+import entry58 from "./catalog/exa.json" with { type: "json" };
+import entry59 from "./catalog/fetch.json" with { type: "json" };
+import entry60 from "./catalog/filesystem.json" with { type: "json" };
+import entry61 from "./catalog/firecrawl.json" with { type: "json" };
+import entry62 from "./catalog/git.json" with { type: "json" };
+import entry63 from "./catalog/huggingface.json" with { type: "json" };
+import entry64 from "./catalog/kagi.json" with { type: "json" };
+import entry65 from "./catalog/memory.json" with { type: "json" };
+import entry66 from "./catalog/mongodb.json" with { type: "json" };
+import entry67 from "./catalog/neon.json" with { type: "json" };
+import entry68 from "./catalog/obsidian.json" with { type: "json" };
+import entry69 from "./catalog/paypal.json" with { type: "json" };
+import entry70 from "./catalog/playwright.json" with { type: "json" };
+import entry71 from "./catalog/redis.json" with { type: "json" };
+import entry72 from "./catalog/resend.json" with { type: "json" };
+import entry73 from "./catalog/sequential-thinking.json" with { type: "json" };
+import entry74 from "./catalog/superhuman-mail.json" with { type: "json" };
+import entry75 from "./catalog/time.json" with { type: "json" };
 
 export const INTEGRATION_CATALOG_ENTRIES = [
   entry0,
@@ -154,4 +155,5 @@ export const INTEGRATION_CATALOG_ENTRIES = [
   entry72,
   entry73,
   entry74,
+  entry75,
 ];

--- a/integrations/catalog/brainiall-tts.json
+++ b/integrations/catalog/brainiall-tts.json
@@ -1,0 +1,43 @@
+{
+  "id": "brainiall-tts",
+  "name": "Brainiall TTS",
+  "description": "Generate WAV speech in Brazilian Portuguese and other supported languages from an agent.",
+  "categories": [
+    "Audio",
+    "AI"
+  ],
+  "appUrl": "https://app.brainiall.com",
+  "docsUrl": "https://github.com/fasuizu-br/brainiall-tts-mcp",
+  "notes": "Official hosted Streamable HTTP MCP server. Brainiall API usage is metered and synthesis text is sent to Brainiall.",
+  "logoUrl": "https://www.brainiall.com/favicon.ico",
+  "keywords": [
+    "tts",
+    "speech",
+    "voice",
+    "audio",
+    "brazilian portuguese",
+    "accessibility"
+  ],
+  "installHint": "Create a dedicated Brainiall API key, then paste it below. The credential is sent as an Authorization Bearer token.",
+  "connectionOptions": [
+    {
+      "id": "api",
+      "provider": "mcp",
+      "transport": {
+        "kind": "shttp",
+        "url": "https://api.brainiall.com/mcp/tts/mcp"
+      },
+      "auth": {
+        "strategy": "bearer",
+        "authModes": [
+          "bearer"
+        ],
+        "credentialLabel": "Brainiall API key",
+        "credentialPlaceholder": "Paste your Brainiall API key",
+        "credentialHelp": "Create a dedicated key in [Brainiall](https://app.brainiall.com). It is sent as an Authorization Bearer token; usage is metered.",
+        "credentialSecretName": "BRAINIALL_API_KEY",
+        "saveCredentialAsSecretByDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

## Why

OpenHands users currently have no catalog entry for the official hosted Brainiall TTS MCP server. This adds a bounded Streamable HTTP option for Brazilian Portuguese and other supported languages without introducing provider-specific runtime code.

## Summary

- add the Brainiall TTS MCP catalog entry with Bearer authentication
- disclose that synthesis text leaves OpenHands and API usage is metered
- regenerate the static integration catalog index

## Issue Number

None.

## How to Test

Automated validation completed:

```bash
npm run build:integrations
python scripts/sync_extensions.py --check
uv run pytest -q
```

Result: 465 passed, 6 skipped. Catalog schema subset: 111 passed.

Verified end-to-end against the hosted server declared in the catalog entry (`https://api.brainiall.com/mcp/tts/mcp`, Streamable HTTP, bearer auth):

- `initialize` → server responds `brainiall-tts` v2.14.7, protocol `2025-06-18`, session established
- `tools/list` → `synthesize_speech`, `list_voices`, `check_tts_service`
- `tools/call synthesize_speech` → returns an `audio` content block; decoded payload is a valid WAV (202,796 bytes, `RIFF` header) and plays back correctly

The credential is sent as an `Authorization: Bearer` header exactly as described in `installHint`, and metered usage is disclosed in `notes`.

## Video/Screenshots

Not available yet; pending the human Agent Canvas check.

## Notes

The server is hosted by Brainiall. The integration stores a dedicated key as a secret by default, sends it as an Authorization Bearer token, and does not add a popularity rank. This contribution was AI-assisted.
