### PR TITLE
chore(slack-monitor): tell agent to format links for Slack

### DIFF
--- a/skills/slack-channel-monitor/scripts/main.py
+++ b/skills/slack-channel-monitor/scripts/main.py
@@ -933,7 +933,7 @@ def _process_trigger_message(
         f"the user request explicitly refers to them.\n\n"
         f"When you are finished, summarise what you did clearly — that summary "
         f"will be posted back to the Slack thread. "
-        f"Understand that your response will be displayed in Slack, so format any links appropriately for Slack."
+        f"Understand that your response will be displayed in Slack, so format any links appropriately for Slack. Do NOT bold the links on Slack."
     )
 
     try:

--- a/skills/slack-channel-monitor/scripts/main.py
+++ b/skills/slack-channel-monitor/scripts/main.py
@@ -932,7 +932,8 @@ def _process_trigger_message(
         f"interactions and are NOT directed at you. Do not act on them unless "
         f"the user request explicitly refers to them.\n\n"
         f"When you are finished, summarise what you did clearly — that summary "
-        f"will be posted back to the Slack thread."
+        f"will be posted back to the Slack thread. "
+        f"Your response will be displayed in Slack, so format the links appropriately for Slack."
     )
 
     try:

--- a/skills/slack-channel-monitor/scripts/main.py
+++ b/skills/slack-channel-monitor/scripts/main.py
@@ -933,7 +933,7 @@ def _process_trigger_message(
         f"the user request explicitly refers to them.\n\n"
         f"When you are finished, summarise what you did clearly — that summary "
         f"will be posted back to the Slack thread. "
-        f"Your response will be displayed in Slack, so format the links appropriately for Slack."
+        f"Understand that your response will be displayed in Slack, so format any links appropriately for Slack."
     )
 
     try:


### PR DESCRIPTION
## What

Appends a note to the end of the Slack automation initial prompt (in `skills/slack-channel-monitor/scripts/main.py`) reminding the agent that its response is displayed in Slack, so links should be formatted appropriately for Slack.

## Why

Requested in the #slack-monitor-conversations channel so the automation surfaces Slack-friendly link formatting in its replies.

## Changes

- `skills/slack-channel-monitor/scripts/main.py`: added sentence `Your response will be displayed in Slack, so format the links appropriately for Slack.` to the `initial_prompt` string.

---

_This PR was created by an AI agent (OpenHands) on behalf of @VascoSch92._