### PR TITLE
test(skills): remove useless category-count snapshot test

### DIFF
--- a/tests/test_skills_catalog.py
+++ b/tests/test_skills_catalog.py
@@ -373,18 +373,6 @@ SKILL_CATEGORY_IDS = {
 # Adding entries would mean creating .plugin/plugin.json and vendor symlinks (see test_skill_plugin_loading.py), which publishes them as Codex/Claude Code plugins.
 SKILLS_WITHOUT_MARKETPLACE_ENTRY = {"qa-changes", "release-notes"}
 
-EXPECTED_CATEGORY_COUNTS = {
-    "environment": 10,
-    "automations": 9,
-    "code-hosting": 8,
-    "agent-authoring": 8,
-    "code-quality": 6,
-    "integrations": 6,
-    "writing": 4,
-    "design": 2,
-    "other": 1,
-}
-
 
 def _marketplace_skill_categories() -> dict[str, str]:
     """Map skill directory name -> category, across every marketplace manifest."""
@@ -416,12 +404,6 @@ class TestMarketplaceSkillCategories:
         }
         uncovered = dirs - set(_marketplace_skill_categories())
         assert uncovered == SKILLS_WITHOUT_MARKETPLACE_ENTRY
-
-    def test_category_distribution_is_balanced(self):
-        from collections import Counter
-
-        counts = dict(Counter(_marketplace_skill_categories().values()))
-        assert counts == EXPECTED_CATEGORY_COUNTS
 
     def test_plugin_entries_keep_their_own_taxonomy(self):
         """Plugin entries are for Claude Code browsing and must not be rewritten."""


### PR DESCRIPTION
## Why

`test_category_distribution_is_balanced` pins the exact number of marketplace skills in each category. It fails on every catalog change — adding a skill or recategorizing one — without teaching anything. The new distribution is simply the result of the edit, so the test provides no signal; it just forces a churn of an unrelated snapshot constant on every skill PR.

## What

- Remove `test_category_distribution_is_balanced` from `tests/test_skills_catalog.py`.
- Remove its now-unused `EXPECTED_CATEGORY_COUNTS` constant.

The remaining marketplace-category tests are kept, and they're the ones that actually validate behavior:
- `test_every_skill_entry_uses_a_known_category` — categories are from the allowed set.
- `test_uncovered_skills_are_exactly_the_known_exceptions` — the known skills with no marketplace entry.
- `test_plugin_entries_keep_their_own_taxonomy` — plugin entries aren't coerced into the skill taxonomy.

## How to Test

`pytest tests/test_skills_catalog.py` — all remaining tests pass.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

---

*This pull request was created by an AI agent (OpenHands) on behalf of enyst.*

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/88125697-6d01-4d9c-980e-39ec706a29c1)