### PR TITLE
fix(github): document the credential form an installation token accepts

### DIFF
--- a/skills/github/README.md
+++ b/skills/github/README.md
@@ -24,7 +24,7 @@ Examples:
 - `gh pr checks 200 --watch --interval 10` to check until completed.
 </IMPORTANT>
 
-If you encounter authentication issues when pushing to GitHub (such as password prompts or permission errors), the old token may have expired. In such case, update the remote URL to include the current token: `git remote set-url origin https://${GITHUB_TOKEN}@github.com/username/repo.git`
+`GITHUB_TOKEN` may be a GitHub App installation token rather than a personal access token. It authenticates as the **password**, with the fixed username `x-access-token`, so `https://${GITHUB_TOKEN}@github.com/...` fails with `could not read Password` — it puts the token in the username field and leaves the password empty. A `403 Resource not accessible by integration` from `GET /user` is also normal for such a token and does not indicate a credential problem; check with a repository-scoped call instead. See `SKILL.md` for the working forms.
 
 Here are some instructions for pushing, but ONLY do this if the user asks you to:
 * NEVER push directly to the `main` or `master` branch

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -20,7 +20,24 @@ Examples:
 
 Windows PowerShell equivalents for the multi-line shell snippets below are in `references/windows.md`.
 
-If you encounter authentication issues when pushing to GitHub (such as password prompts or permission errors), the old token may have expired. In such case, update the remote URL to include the current token: `git remote set-url origin https://${GITHUB_TOKEN}@github.com/username/repo.git`
+`GITHUB_TOKEN` may be a GitHub App installation token rather than a personal access token. Two things follow, and both look like a revoked credential when they are not:
+
+* The token authenticates as the **password**, with the fixed username `x-access-token`. `https://${GITHUB_TOKEN}@github.com/...` puts it in the username field with no password, so git asks for one, and where `GIT_TERMINAL_PROMPT=0` is set the command fails with `could not read Password`. That is a malformed URL, not an expired token.
+* `GET /user` and `gh api user` always answer `403 Resource not accessible by integration` for an installation token, because they are user-scoped endpoints an installation cannot call. That 403 says nothing about the token. To check it, call something repository-scoped such as `curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/<owner>/<repo>`.
+
+Your checkout may already have a credential helper configured for `origin`, in which case `git fetch origin` and `git push origin` authenticate on their own — try them before changing anything. If a push does fail on authentication, supply credentials without rewriting the remote URL:
+
+```bash
+git push "https://x-access-token:${GITHUB_TOKEN}@github.com/owner/repo.git" HEAD:my-branch
+```
+
+Pass the URL to the single command rather than `git remote set-url origin`, so the token is not written into `.git/config`. To keep it out of the command line as well, use an askpass helper:
+
+```bash
+printf '%s\n' '#!/bin/sh' 'case "$1" in *Username*) printf %s x-access-token ;; *) printf %s "$GITHUB_TOKEN" ;; esac' > /tmp/git-askpass
+chmod 700 /tmp/git-askpass
+GIT_ASKPASS=/tmp/git-askpass GIT_TERMINAL_PROMPT=0 git push origin HEAD:my-branch
+```
 
 Here are some instructions for pushing, but ONLY do this if the user asks you to:
 * NEVER push directly to the `main` or `master` branch

--- a/skills/github/references/windows.md
+++ b/skills/github/references/windows.md
@@ -7,8 +7,18 @@ Use these PowerShell forms when running this skill's GitHub commands natively on
 PowerShell environment variables use `$env:NAME`:
 
 ```powershell
-git remote set-url origin "https://$($env:GITHUB_TOKEN)@github.com/username/repo.git"
+$env:GITHUB_TOKEN
 ```
+
+## Supplying Credentials to Git
+
+Prefer `git push origin` — the checkout may already have a credential helper. When it does not, pass the token as the **password** with the username `x-access-token`. Putting the token in the username field (`https://$($env:GITHUB_TOKEN)@github.com/...`) leaves the password empty and fails with `could not read Password`.
+
+```powershell
+git push "https://x-access-token:$($env:GITHUB_TOKEN)@github.com/owner/repo.git" HEAD:my-branch
+```
+
+Pass the URL to the single command rather than `git remote set-url origin`, so the token is not written into `.git/config`.
 
 ## Chained Git Commands
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

- [ ] A human has tested these changes.

---

## Why

The GitHub skill's recovery step for a failed push cannot work when `GITHUB_TOKEN` is a GitHub App installation token:

```
git remote set-url origin https://${GITHUB_TOKEN}@github.com/username/repo.git
```

That puts the token in the **username** field with no password. An installation token is only accepted as the **password**, with the fixed username `x-access-token`. Git therefore asks for a password, and under `GIT_TERMINAL_PROMPT=0` the command dies with `could not read Password` — the very failure the paragraph offers itself as the cure for.

The same paragraph attributes the failure to an expired token. An agent that follows that lead and probes the token with `GET /user` receives `403 Resource not accessible by integration`, which is the only answer a user-scoped endpoint can give an installation, and reads it as confirmation.

We hit this in production. A run finished its work, committed it, then reported to the user that GitHub write access had been revoked and stopped without opening a pull request. The token was fine — a sibling run pushed the same branch with the same token minutes earlier, because it happened to improvise an `x-access-token` askpass helper instead of following the documented recipe. Whether the work shipped came down to which credential form the agent guessed.

## Summary

- `skills/github/SKILL.md`: replace the broken `remote set-url` recipe with the field the token actually authenticates in; state that a 403 from `GET /user` / `gh api user` is normal for an installation token and name a repository-scoped check that answers; prefer plain `git push origin` first, since the checkout often already has a credential helper configured.
- Keep the token out of `.git/config` by passing the URL to the single command instead of `remote set-url`, and offer an askpass form for keeping it off the command line too.
- `skills/github/README.md` and `skills/github/references/windows.md` carried the same recipe and are updated to match.

## Issue Number

None — found from a production trace rather than a filed issue.

## How to Test

Both snippets in the diff were run before proposing them.

The askpass helper answers each prompt with the right value:

```console
$ printf '%s\n' '#!/bin/sh' 'case "$1" in *Username*) printf %s x-access-token ;; *) printf %s "$GITHUB_TOKEN" ;; esac' > /tmp/git-askpass
$ chmod 700 /tmp/git-askpass && sh -n /tmp/git-askpass   # valid POSIX sh
$ GITHUB_TOKEN=ghs_tok /tmp/git-askpass "Username for 'https://github.com': "
x-access-token
$ GITHUB_TOKEN=ghs_tok /tmp/git-askpass "Password for 'https://x-access-token@github.com': "
ghs_tok
```

Git accepts the URL form without prompting:

```console
$ git ls-remote "https://x-access-token:${GITHUB_TOKEN}@github.com/OpenHands/extensions.git" HEAD
91f27d40bbb3e3dae6a6fd750cc3a055fe7746e9	HEAD
```

To reproduce the documented failure, run the old recipe against a private repository with prompts disabled:

```console
$ GIT_TERMINAL_PROMPT=0 git push "https://${GITHUB_TOKEN}@github.com/<owner>/<private-repo>.git" HEAD:probe
fatal: could not read Password for 'https://****@github.com': terminal prompts disabled
```

And confirm the probe that misleads:

```console
$ curl -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user
403
$ curl -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/<owner>/<repo>
200
```

## Video/Screenshots

N/A — documentation only, no runtime behavior in this repository.

## Notes

- Scope is deliberately limited to the `github` skill. The `gitlab` skill already uses the correct `oauth2:<token>@` form. The `azure-devops` and `bitbucket-data-center` skills carry the same token-as-username shape and are likely wrong for the same reason, but their token semantics are not what this change verified, so they are untouched — happy to follow up if you would like them covered.
- No behavior in this repository changes; the effect is on agents that read this skill at runtime.
