### PR TITLE
fix(qa-changes): unpin lmnr

### DIFF
--- a/plugins/qa-changes/action.yml
+++ b/plugins/qa-changes/action.yml
@@ -160,7 +160,7 @@ runs:
         # so we enforce the time limit via the coreutils timeout command.
         TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
         timeout "${TIMEOUT_SECONDS}" \
-          uv run --no-project --with openhands-sdk --with openhands-tools --with 'lmnr<0.7.53' \
+          uv run --no-project --with openhands-sdk --with openhands-tools --with lmnr \
             python ../extensions/plugins/qa-changes/scripts/agent_script.py
 
     - name: Upload logs as artifact


### PR DESCRIPTION
## Problem

`QA Changes by OpenHands/qa-changes` fails on **every** PR in every consuming repo, at dependency-import time, before the agent starts:

```
ImportError: cannot import name 'detached_delegate_context' from 'openhands.sdk.observability.laminar'
```

## Root cause

`plugins/qa-changes/action.yml` bootstraps with `--with 'lmnr<0.7.53'`, added in 8c4366c when lmnr 0.7.53 removed the `rollout_entrypoint` observe kwarg that the SDK still forwarded.

The SDK fixed that upstream and moved forward:

| openhands-sdk | lmnr requirement |
| --- | --- |
| <= 1.36.1 (to 2026-07-15) | `lmnr>=0.7.47,<0.7.53` |
| >= 1.37.0 (2026-07-23) | `lmnr>=0.7.56,<0.8.0` |

Since 1.37.0 the pin makes every newer SDK uninstallable, so uv backtracks to **openhands-sdk 1.36.1**. But `openhands-tools` declares `openhands-sdk` with no version bound, so it stays at **latest** — silent version skew.

That skew was harmless until **openhands-tools 1.41.0** (2026-08-06), which added to `openhands/tools/task/manager.py`:

```python
from openhands.sdk.observability.laminar import detached_delegate_context
```

a symbol that does not exist in sdk 1.36.1. QA Changes has been broken repo-wide since that release.

## Fix

Drop the pin. The SDK now pins its own compatible lmnr range, so the workaround is redundant *and* actively breaking. This matches `plugins/pr-review/action.yml`, which already uses unpinned `--with lmnr`. qa-changes was the only plugin still carrying the stale pin.

## Verification

Before (current `main` spec) — reproduces the failure:

```
openhands-sdk 1.36.1   openhands-tools 1.42.1   lmnr 0.7.52
has detached_delegate_context: False
```

After (this change) — resolves consistently and every import in `agent_script.py` succeeds:

```
openhands-sdk 1.42.1   openhands-tools 1.42.1   lmnr 0.7.59
ALL IMPORTS OK
```

Also confirmed sdk 1.36.1 + tools 1.40.1 still imports fine, which pins the regression precisely to openhands-tools 1.41.0.

## Follow-up (not in this PR)

`openhands-tools` does not bound `openhands-sdk`, so *any* constraint that holds the SDK back reproduces this skew with no error until a symbol goes missing. Pinning both to the same release (`--with 'openhands-sdk==X' --with 'openhands-tools==X'`, bumped by dependabot) would turn a future recurrence into a resolution error instead of a mid-run `ImportError`.
