### PR TITLE
feat: add Knowl integration

### DIFF
--- a/integrations/catalog-index.js
+++ b/integrations/catalog-index.js
@@ -67,17 +67,18 @@ import entry61 from "./catalog/firecrawl.json" with { type: "json" };
 import entry62 from "./catalog/git.json" with { type: "json" };
 import entry63 from "./catalog/huggingface.json" with { type: "json" };
 import entry64 from "./catalog/kagi.json" with { type: "json" };
-import entry65 from "./catalog/memory.json" with { type: "json" };
-import entry66 from "./catalog/mongodb.json" with { type: "json" };
-import entry67 from "./catalog/neon.json" with { type: "json" };
-import entry68 from "./catalog/obsidian.json" with { type: "json" };
-import entry69 from "./catalog/paypal.json" with { type: "json" };
-import entry70 from "./catalog/playwright.json" with { type: "json" };
-import entry71 from "./catalog/redis.json" with { type: "json" };
-import entry72 from "./catalog/resend.json" with { type: "json" };
-import entry73 from "./catalog/sequential-thinking.json" with { type: "json" };
-import entry74 from "./catalog/superhuman-mail.json" with { type: "json" };
-import entry75 from "./catalog/time.json" with { type: "json" };
+import entry65 from "./catalog/knowl.json" with { type: "json" };
+import entry66 from "./catalog/memory.json" with { type: "json" };
+import entry67 from "./catalog/mongodb.json" with { type: "json" };
+import entry68 from "./catalog/neon.json" with { type: "json" };
+import entry69 from "./catalog/obsidian.json" with { type: "json" };
+import entry70 from "./catalog/paypal.json" with { type: "json" };
+import entry71 from "./catalog/playwright.json" with { type: "json" };
+import entry72 from "./catalog/redis.json" with { type: "json" };
+import entry73 from "./catalog/resend.json" with { type: "json" };
+import entry74 from "./catalog/sequential-thinking.json" with { type: "json" };
+import entry75 from "./catalog/superhuman-mail.json" with { type: "json" };
+import entry76 from "./catalog/time.json" with { type: "json" };
 
 export const INTEGRATION_CATALOG_ENTRIES = [
   entry0,
@@ -156,4 +157,5 @@ export const INTEGRATION_CATALOG_ENTRIES = [
   entry73,
   entry74,
   entry75,
+  entry76,
 ];

--- a/integrations/catalog/knowl.json
+++ b/integrations/catalog/knowl.json
@@ -17,6 +17,7 @@
     "decisions",
     "persistence"
   ],
+  "installHint": "No credentials or configuration required. Knowl stores memory locally per project; nothing is sent to a hosted service.",
   "connectionOptions": [
     {
       "id": "none",

--- a/integrations/catalog/knowl.json
+++ b/integrations/catalog/knowl.json
@@ -1,0 +1,39 @@
+{
+  "id": "knowl",
+  "name": "Knowl",
+  "description": "Project memory for coding agents. Records decisions, constraints and architecture as typed atoms, and retires superseded ones at write time so stale facts stop coming back in retrieval.",
+  "categories": [
+    "Knowledge base",
+    "Engineering"
+  ],
+  "appUrl": "https://knowl.cloud",
+  "docsUrl": "https://github.com/dat999zx/knowl",
+  "iconBg": "#04121A",
+  "keywords": [
+    "memory",
+    "context",
+    "knowledge",
+    "recall",
+    "decisions",
+    "persistence"
+  ],
+  "connectionOptions": [
+    {
+      "id": "none",
+      "provider": "mcp",
+      "transport": {
+        "kind": "stdio",
+        "serverName": "knowl",
+        "command": "npx",
+        "args": [
+          "-y",
+          "@dat999zx/knowl",
+          "serve"
+        ]
+      },
+      "auth": {
+        "strategy": "none"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
HUMAN:
Ran `npx -y @dat999zx/knowl@5.6.0 serve` in a fresh Windows cmd.exe shell. The MCP server started and reported ready in 0ms over stdio. I'm a co-founder of Knowl, so treat the description as a claim to check rather than take on faith.

- [x] A human has tested these changes.

---

## Why

The catalog's only memory entry is `memory`, the reference `@modelcontextprotocol/server-memory`, which is a key-value store scoped to conversations. There is no entry for project memory: the decisions, constraints and architecture of a codebase, and which of them are still true.

Knowl fills that gap. It resolves conflicts at **write** time: a fact whose subject and relation match one already stored retires the earlier record, so the stale value never becomes a retrieval candidate. In MemoryAgentBench's own harness on FactConsolidation-SH at 262k, that mechanism is worth 89.0 with supersession on against 73.0 with it off.

## Summary

- Adds `integrations/catalog/knowl.json`
- Regenerates `integrations/catalog-index.js` via `npm run build:integrations`
- stdio MCP transport, `npx -y @dat999zx/knowl serve`
- `auth.strategy: "none"`, so it is local-first with no credentials and nothing to configure in the install modal

## Issue Number

n/a

## How to Test

```bash
npx -y @dat999zx/knowl serve
```

Speaks MCP over stdio and registers its tools. `npx -y @dat999zx/knowl --help` lists the CLI surface. Package is published at `@dat999zx/knowl` (5.6.0), source at https://github.com/dat999zx/knowl. Verified on Windows via `cmd.exe`, where the `npx` form works without the `knowl.cmd` shim the project's own README mentions.

The entry matches the `IntegrationCatalogEntry` shape in `integrations/index.d.ts`, with required `id`, `name`, `description`, `docsUrl` and `connectionOptions` all present. Categories reuse existing vocabulary (`Knowledge base` from notion, `Engineering` from github and linear) rather than introducing new values.

Not tested through the OpenHands install modal, since I don't have that environment.

## Video/Screenshots

n/a. Catalog metadata only, no UI change beyond the new entry appearing in the list.

## Notes

Disclosure: I'm a co-founder of Knowl. Happy to adjust the description, categories or `iconBg` to house style, or drop the benchmark reference from this body if you'd rather the catalog stay claim-free.
