### PR TITLE
chore(automations): move the GitHub repository monitor to Beta

### DIFF
--- a/automations/interface.json
+++ b/automations/interface.json
@@ -151,7 +151,6 @@
   "featuredAutomationIds": [
     "github-pr-reviewer",
     "github-issue-to-pr",
-    "github-repo-monitor",
     "slack-channel-monitor"
   ],
   "responderIntegrationIds": ["github", "slack"]


### PR DESCRIPTION
Moves `github-repo-monitor` out of **Start from a proven workflow** and into the
**Beta** group on the templates page.

## The whole change

```diff
   "featuredAutomationIds": [
     "github-pr-reviewer",
     "github-issue-to-pr",
-    "github-repo-monitor",
     "slack-channel-monitor"
   ],
```

`featuredAutomationIds` is the only thing the templates page splits on, so
removing the id is sufficient and nothing else needs to move. The entry stays in
the catalog, keeps its setup flow and its card, and launches exactly as before —
it is shown under Beta instead of Proven.

## Why keep the set small

Proven reads as a recommendation without qualification, which is only worth
something if the list is deliberate. It is not derived from `popularityRank` for
the same reason — `slack-standup-digest@94` outranks `slack-channel-monitor@92`
and is still Beta.

## Verification

- 628 passed, 12 skipped
- `scripts/sync_extensions.py --check` clean; `npm run build` regenerated with
  no drift — `interface.json` is hand-authored and not inlined into any
  generated index, so this is a one-file change
- `test_featured_automations_resolve_to_catalog_entries` still passes: it checks
  that every featured id names a real entry, which removal cannot break