### PR TITLE
fix: use Notion MCP token environment variable

### DIFF
--- a/integrations/catalog/notion.json
+++ b/integrations/catalog/notion.json
@@ -52,7 +52,7 @@
         ],
         "envFields": [
           {
-            "key": "NOTION_API_KEY",
+            "key": "NOTION_TOKEN",
             "label": "Internal integration token",
             "type": "password",
             "placeholder": "ntn_...",

--- a/tests/test_catalog_schema.py
+++ b/tests/test_catalog_schema.py
@@ -78,16 +78,6 @@ def test_schema_requires_catalog_and_install_metadata() -> None:
         assert any(field in error.message for error in errors), errors
 
 
-
-def test_notion_mcp_uses_supported_token_environment_variable() -> None:
-    entry = json.loads((CATALOG_DIR / "notion.json").read_text())
-    api_option = next(
-        option for option in entry["connectionOptions"] if option["id"] == "api"
-    )
-
-    assert api_option["transport"]["envFields"][0]["key"] == "NOTION_TOKEN"
-
-
 @pytest.mark.parametrize(
     ("entry_id", "resource_type", "cardinality", "selection_mode"),
     [

--- a/tests/test_catalog_schema.py
+++ b/tests/test_catalog_schema.py
@@ -78,6 +78,16 @@ def test_schema_requires_catalog_and_install_metadata() -> None:
         assert any(field in error.message for error in errors), errors
 
 
+
+def test_notion_mcp_uses_supported_token_environment_variable() -> None:
+    entry = json.loads((CATALOG_DIR / "notion.json").read_text())
+    api_option = next(
+        option for option in entry["connectionOptions"] if option["id"] == "api"
+    )
+
+    assert api_option["transport"]["envFields"][0]["key"] == "NOTION_TOKEN"
+
+
 @pytest.mark.parametrize(
     ("entry_id", "resource_type", "cardinality", "selection_mode"),
     [


### PR DESCRIPTION
## Summary
- configure the Notion MCP integration with `NOTION_TOKEN`, the variable supported by `@notionhq/notion-mcp-server`
- add regression coverage for the credential environment variable

## Validation
- `npm run build:integrations`
- `uv run --group test pytest -q tests/test_catalog_schema.py`
- `python scripts/sync_extensions.py --check`

_This pull request was created by an AI agent (OpenHands) on behalf of Devin Vinson._