### PR TITLE
docs: document extensions repository boundaries

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -7,6 +7,13 @@ triggers:
 
 # Extensions Repo — Code Review Guidelines
 
+## Repository Boundaries
+
+Review whether a PR belongs in this public extensions registry. Skills, plugins, automations, and integrations belong here; Agent Server behavior and API endpoints belong in [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk), typed browser API access belongs in [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client), UI belongs in [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands), and scheduling/dispatch lifecycle behavior belongs in [`OpenHands/automation`](https://github.com/OpenHands/automation).
+
+If a PR is opened in the wrong repository, explicitly recommend that it may need to be closed and moved to the repository that owns the change rather than merged here. Apply the repository's contribution and review guidance to every PR.
+
+
 ## SDK Documentation Placement
 
 If a PR adds or modifies OpenHands SDK-specific documentation (API guides, SDK usage examples, SDK feature descriptions), flag it:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,20 @@
 This repository (`OpenHands/extensions`) is the **public extensions registry** for OpenHands.
 It contains **shareable skills and plugins** that can be loaded by OpenHands (CLI/GUI/Cloud) and by client code using the **Software Agent SDK**.
 
+
+## Cross-Repository Boundaries
+
+This repository owns the public registry of reusable OpenHands skills, plugins, automations, and integrations. These extensions are consumed by OpenHands applications and SDK-based clients.
+
+Related repositories have distinct responsibilities:
+
+- [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) owns the Python SDK, Agent Server, agent/tool behavior, conversations, workspaces, events, and canonical API.
+- [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client) owns the browser-compatible typed Agent Server client.
+- [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) owns Agent Canvas UI and local-stack orchestration.
+- [`OpenHands/automation`](https://github.com/OpenHands/automation) owns scheduling, webhooks, run history, dispatch, and sandbox lifecycle orchestration.
+
+Put reusable skills, plugins, automations, and integrations here; put backend execution behavior in the SDK, typed API access in `typescript-client`, application UI in Agent Canvas, and scheduling/dispatch lifecycle code in `automation`. If a PR is opened in the wrong repository, explicitly recommend closing and moving it to the owning repository. PRs must follow this repository's applicable contribution and code-review guidance.
+
 ## What this repo contains
 
 - `skills/` — a catalog of skills, **one directory per skill**.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ It contains reusable, shareable skills and plugins that customize agent behavior
 - Skills overview docs: https://docs.openhands.dev/overview/skills
 - SDK skill guide: https://docs.openhands.dev/sdk/guides/skill
 
+
+## Repository boundaries
+
+`OpenHands/extensions` is the public registry for reusable skills, plugins, automations, and integrations. [`OpenHands/software-agent-sdk`](https://github.com/OpenHands/software-agent-sdk) owns Agent Server execution and the canonical API, [`OpenHands/typescript-client`](https://github.com/OpenHands/typescript-client) owns typed browser access to that API, [`OpenHands/OpenHands`](https://github.com/OpenHands/OpenHands) owns Agent Canvas UI, and [`OpenHands/automation`](https://github.com/OpenHands/automation) owns scheduling, webhooks, run history, dispatch, and sandbox lifecycle orchestration.
+
+Put reusable extension artifacts here rather than in application repositories. If a PR is opened in the wrong repository, close and move it to the repository that owns the change.
+
 ## Repository Layout
 
 ### Skills


### PR DESCRIPTION
HUMAN:

I reviewed the Extensions architecture and contributor guidance, then documented its ownership boundaries in the broader OpenHands system.

AGENT:

This pull request was created by an AI agent (OpenHands) on behalf of the user.

## Why

Contributors need to distinguish reusable extension artifacts from Agent Server behavior, typed API access, Agent Canvas UI, and automation lifecycle code. This prevents duplicated logic and misplaced PRs.

## Summary

- Document Extensions ownership in `AGENTS.md` and `README.md`.
- Add repository-placement guidance to the custom code-review guide.
- Explain the roles of SDK, TypeScript client, Canvas, and automation repositories.

## Issue Number

Fixes #497

## How to Test

Review the three changed Markdown files for accurate repository links and ownership descriptions.

## Video/Screenshots

Not applicable: documentation-only change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore
