### PR TITLE
fix(datadog): use correct MCP authentication headers

### DIFF
--- a/integrations/catalog/datadog.json
+++ b/integrations/catalog/datadog.json
@@ -43,7 +43,7 @@
         "urlEditable": true,
         "headerFields": [
           {
-            "key": "DD_API_KEY",
+            "key": "DD-API-KEY",
             "label": "Datadog API key",
             "type": "password",
             "required": true,
@@ -51,7 +51,7 @@
             "helperText": "Created in Datadog under Organization Settings → API Keys. Used to authenticate to the Datadog MCP server. See the [setup docs](https://docs.datadoghq.com/mcp_server/setup/?tab=other#authentication)."
           },
           {
-            "key": "DD_APPLICATION_KEY",
+            "key": "DD-APPLICATION-KEY",
             "label": "Datadog Application key",
             "type": "password",
             "required": true,

--- a/integrations/index.d.ts
+++ b/integrations/index.d.ts
@@ -17,7 +17,7 @@ export type IntegrationTransport =
       apiKeyOptional?: boolean;
       /**
        * Named request headers the user must supply (e.g. Datadog's
-       * `DD_API_KEY` / `DD_APPLICATION_KEY`). Values are sent verbatim as
+       * `DD-API-KEY` / `DD-APPLICATION-KEY`). Values are sent verbatim as
        * headers on every MCP request. The direct analog of stdio's
        * `envFields`: each entry renders one input in the install modal,
        * `type: "password"` entries are secret-saved by default, and

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -93,7 +93,7 @@ def test_remote_no_auth_mcp_entries_are_intentionally_public():
             transport = option.get("transport", {})
             # An option with `headerFields` still requires the user to supply
             # credentials (just via named headers, e.g. Datadog's
-            # DD_API_KEY/DD_APPLICATION_KEY), so it is NOT "public/no-auth".
+            # DD-API-KEY/DD-APPLICATION-KEY), so it is NOT "public/no-auth".
             has_header_credentials = bool(transport.get("headerFields"))
             if (
                 option["provider"] == "mcp"
@@ -119,7 +119,7 @@ def test_datadog_mcp_uses_documented_api_key_headers():
 
     assert [
         field["key"] for field in api_option["transport"]["headerFields"]
-    ] == ["DD_API_KEY", "DD_APPLICATION_KEY"]
+    ] == ["DD-API-KEY", "DD-APPLICATION-KEY"]
 
 
 def test_credential_fields_have_helper_text_and_link():


### PR DESCRIPTION
## Summary

- Use Datadog MCP HTTP header names (`DD-API-KEY` and `DD-APPLICATION-KEY`) instead of environment-variable names.
- Update the public TypeScript documentation and catalog regression test.

## Validation

- `uv run pytest -q tests/test_catalogs.py tests/test_integration_catalog_in_sync.py`
- 30 tests passed.
- Verified the corrected headers connect to the US5 endpoint and discover Datadog MCP tools through the OpenHands Software Agent SDK.

This pull request was created by an AI agent (OpenHands) on behalf of the user.