### PR TITLE
feat(integrations): add free Parallel Search MCP

### DIFF
--- a/integrations/catalog-index.js
+++ b/integrations/catalog-index.js
@@ -72,13 +72,14 @@ import entry66 from "./catalog/memory.json" with { type: "json" };
 import entry67 from "./catalog/mongodb.json" with { type: "json" };
 import entry68 from "./catalog/neon.json" with { type: "json" };
 import entry69 from "./catalog/obsidian.json" with { type: "json" };
-import entry70 from "./catalog/paypal.json" with { type: "json" };
-import entry71 from "./catalog/playwright.json" with { type: "json" };
-import entry72 from "./catalog/redis.json" with { type: "json" };
-import entry73 from "./catalog/resend.json" with { type: "json" };
-import entry74 from "./catalog/sequential-thinking.json" with { type: "json" };
-import entry75 from "./catalog/superhuman-mail.json" with { type: "json" };
-import entry76 from "./catalog/time.json" with { type: "json" };
+import entry70 from "./catalog/parallel-search.json" with { type: "json" };
+import entry71 from "./catalog/paypal.json" with { type: "json" };
+import entry72 from "./catalog/playwright.json" with { type: "json" };
+import entry73 from "./catalog/redis.json" with { type: "json" };
+import entry74 from "./catalog/resend.json" with { type: "json" };
+import entry75 from "./catalog/sequential-thinking.json" with { type: "json" };
+import entry76 from "./catalog/superhuman-mail.json" with { type: "json" };
+import entry77 from "./catalog/time.json" with { type: "json" };
 
 export const INTEGRATION_CATALOG_ENTRIES = [
   entry0,
@@ -158,4 +159,5 @@ export const INTEGRATION_CATALOG_ENTRIES = [
   entry74,
   entry75,
   entry76,
+  entry77,
 ];

--- a/integrations/catalog/parallel-search.json
+++ b/integrations/catalog/parallel-search.json
@@ -1,0 +1,26 @@
+{
+  "id": "parallel-search",
+  "name": "Parallel Search",
+  "description": "Search the web and fetch page content with Parallel Search MCP. Free for light use, with no API key required.",
+  "docsUrl": "https://docs.parallel.ai/integrations/mcp/search-mcp",
+  "keywords": [
+    "search",
+    "web",
+    "research",
+    "fetch",
+    "extraction"
+  ],
+  "connectionOptions": [
+    {
+      "id": "none",
+      "provider": "mcp",
+      "transport": {
+        "kind": "shttp",
+        "url": "https://search.parallel.ai/mcp"
+      },
+      "auth": {
+        "strategy": "none"
+      }
+    }
+  ]
+}

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -85,7 +85,12 @@ def test_catalog_entries_have_required_fields():
 
 
 def test_remote_no_auth_mcp_entries_are_intentionally_public():
-    public_remote_mcp_ids = {"cloudflare-docs", "deepwiki", "huggingface"}
+    public_remote_mcp_ids = {
+        "cloudflare-docs",
+        "deepwiki",
+        "huggingface",
+        "parallel-search",
+    }
 
     actual = set()
     for entry in load_catalog_entries("integrations/catalog"):

--- a/tests/test_live_integration_smoke.py
+++ b/tests/test_live_integration_smoke.py
@@ -24,6 +24,11 @@ Preconditions:
 
 Evidence lines are printed as ``[OSS-5193] ...`` and contain only tool names,
 counts, and provider error codes — never credentials or message content.
+
+The anonymous Parallel Search smoke test needs no credentials and runs only
+when explicitly enabled:
+
+    RUN_PARALLEL_MCP_LIVE=1 uv run pytest tests/test_live_integration_smoke.py -k parallel -s
 """
 
 import json
@@ -33,6 +38,7 @@ from contextlib import contextmanager
 import mcp.types
 import pytest
 from openhands.sdk.mcp import MCPError, MCPServer, MCPTimeoutError, create_mcp_tools
+from openhands.sdk.mcp.definition import MCPToolObservation
 
 from openhands_extensions import get_integration_catalog_entry_model
 
@@ -138,6 +144,67 @@ def _first_advertised(tool_names, candidates):
         f"{sorted({name for name, _ in candidates})} are advertised; "
         f"server offers: {sorted(tool_names)}"
     )
+
+
+@pytest.mark.skipif(
+    os.environ.get("RUN_PARALLEL_MCP_LIVE") != "1",
+    reason="set RUN_PARALLEL_MCP_LIVE=1 to run the anonymous Parallel MCP smoke test",
+)
+def test_parallel_anonymous_search_fetch_and_invalid_arguments():
+    option = _installable_option("parallel-search")
+    assert option.auth.strategy == "none"
+    assert option.transport.kind == "shttp"
+    server = MCPServer.model_validate(
+        {"url": option.transport.url, "transport": "http"}
+    )
+
+    with create_mcp_tools({"parallel-search": server}, timeout=HTTP_TIMEOUT) as client:
+        assert {"web_search", "web_fetch"} <= {tool.name for tool in client.tools}
+        for name, arguments in (
+            (
+                "web_search",
+                {
+                    "objective": "Find the official Python documentation for dictionaries.",
+                    "search_queries": ["site:docs.python.org dictionary tutorial"],
+                },
+            ),
+            (
+                "web_fetch",
+                {"urls": ["https://docs.python.org/3/tutorial/datastructures.html"]},
+            ),
+        ):
+            result = client.call_async_from_sync(
+                client.call_tool_mcp,
+                name=name,
+                arguments=arguments,
+                timeout=HTTP_TIMEOUT,
+            )
+            assert not result.isError
+            text = "\n".join(
+                block.text
+                for block in result.content
+                if isinstance(block, mcp.types.TextContent)
+            )
+            payload = json.loads(text)
+            assert payload == result.structuredContent
+            assert payload["results"]
+            assert all(
+                item["url"].startswith(("http://", "https://"))
+                for item in payload["results"]
+            )
+            assert any(item.get("excerpts") for item in payload["results"])
+            observation = MCPToolObservation.from_call_tool_result(name, result)
+            assert not observation.is_error
+            assert text in [block.text for block in observation.content]
+
+        invalid = client.call_async_from_sync(
+            client.call_tool_mcp,
+            name="web_search",
+            arguments={"objective": "Find Python documentation"},
+            timeout=HTTP_TIMEOUT,
+        )
+        assert invalid.isError
+        assert MCPToolObservation.from_call_tool_result("web_search", invalid).is_error
 
 
 @requires_github


### PR DESCRIPTION
- [ ] A human has tested these changes.

HUMAN: Rowan reported on September 21, 2026 that his local merge and catalog rebuild passed 984 tests plus the live Parallel search/fetch test. No hosted UI testing is claimed.

## Why

This adds free, keyless web search and page fetching to the shared integration catalog. OpenHands users can add Parallel Search through the normal MCP settings instead of entering its URL manually. I'm George from Parallel.

For context, Parallel Search Fast scores 80 F1 on Artificial Analysis's [DeepSearchQA benchmark](https://artificialanalysis.ai/agents/search-api?search-api-quality-chart=deepsearchqa#search-api-quality-chart-tabs), and its [Time per Task chart](https://artificialanalysis.ai/agents/search-api?search-api-quality-chart=deepsearchqa#latency) reports 18.5 seconds per task. Fast is also the mode used by anonymous Search MCP. These are search API benchmark results, not measured OpenHands performance.

## Summary

- Add an opt-in, no-auth Streamable HTTP entry for [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) and regenerate the JavaScript index.
- Update the public-server allowlist and add an opt-in live test for search, page fetching, source links and invalid arguments.
- Preserve existing integrations, search defaults and saved settings.

## Issue Number

Fixes #604

## How to Test

```bash
uv sync --group test
npm run build:integrations
uv run pytest -q
RUN_PARALLEL_MCP_LIVE=1 uv run pytest -q tests/test_live_integration_smoke.py -k parallel
```

Validation after merging upstream `main` and regenerating the integration index on September 21, 2026: Python 3.12.13 with openhands-sdk 1.49.2 passed 985 tests, with 25 skipped. The anonymous live Parallel test passed search, page fetching, source-bearing results and invalid arguments. Extension sync and deprecation checks also passed; extension sync reported an existing non-blocking marketplace coverage warning for `plugins/issue-duplicate-checker`.

Earlier validation with this package linked into Agent Canvas passed 52 focused component/helper tests, including credential-free installation and preservation of sibling servers. Those consumer tests were not rerun for this merge, and the full hosted UI was not exercised.

With this catalog version installed in Agent Canvas, open MCP settings, choose Parallel Search from the marketplace and add its no-auth connection. It uses `https://search.parallel.ai/mcp` and requires no API key. The enabled server exposes `web_search` and `web_fetch` through the existing MCP tool path.

## Video/Screenshots

No hosted UI recording was captured for this catalog and test change.

## Notes

Search queries and fetched URLs are sent to Parallel's hosted service. Anonymous Search MCP is free for light use and rate-limited; model and hosting costs still apply. Availability in released clients follows the catalog release and consumer update.

