### PR TITLE
refactor: name automation templates after the action, not the agent

### DIFF
--- a/automations/README.md
+++ b/automations/README.md
@@ -64,7 +64,7 @@ checks them against the recorded fixtures, so these deletions stay honest rather
 ```jsonc
 {
   "id": "github-pr-reviewer",
-  "name": "GitHub Code Review Agent",
+  "name": "GitHub code review",
   "category": "Code review",
   "description": "...",
   "requires": {

--- a/automations/catalog/github-issue-to-pr/manifest.json
+++ b/automations/catalog/github-issue-to-pr/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "github-issue-to-pr",
-  "name": "GitHub Issue to PR Agent",
+  "name": "GitHub issue to PR",
   "category": "Software development",
   "description": "Watch for a configurable label on GitHub issues, implement the issue in a clone of the default branch, and open a pull request for each label event.",
   "requires": {

--- a/automations/catalog/github-pr-reviewer/manifest.json
+++ b/automations/catalog/github-pr-reviewer/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "github-pr-reviewer",
   "version": "1.0.0",
-  "name": "GitHub Code Review Agent",
+  "name": "GitHub code review",
   "category": "Code review",
   "description": "Watch for a configurable label on GitHub pull requests, inspect full PR and repository context, and post an AI review comment once per label event.",
   "requires": {

--- a/automations/catalog/qa-changes/manifest.json
+++ b/automations/catalog/qa-changes/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "qa-changes",
-  "name": "QA Changes Agent",
+  "name": "QA changes",
   "category": "Code review",
   "description": "When a pull request is opened for review, run the QA changes methodology — set up the environment, exercise the changed behavior as a real user would, and post the outcome by editing the PR description with a QA Agent section.",
   "requires": {

--- a/tests/fixtures/automations/github-pr-reviewer.json
+++ b/tests/fixtures/automations/github-pr-reviewer.json
@@ -50,7 +50,7 @@
             "automationId": "github-pr-reviewer",
             "endpoint": "/v1",
             "draft": {
-              "name": "GitHub Code Review Agent - OpenHands/agent-server-gui",
+              "name": "GitHub code review - OpenHands/agent-server-gui",
               "trigger": {
                 "type": "cron",
                 "schedule": "*/15 * * * *",
@@ -86,7 +86,7 @@
           "method": "POST",
           "path": "/v1",
           "body": {
-            "name": "GitHub Code Review Agent - OpenHands/agent-server-gui",
+            "name": "GitHub code review - OpenHands/agent-server-gui",
             "trigger": {
               "type": "cron",
               "schedule": "*/15 * * * *",
@@ -115,7 +115,7 @@
             "user_id": "1a2b3c4d-0000-4000-8000-000000000001",
             "org_id": "1a2b3c4d-0000-4000-8000-000000000002",
             "model": null,
-            "name": "GitHub Code Review Agent - OpenHands/agent-server-gui",
+            "name": "GitHub code review - OpenHands/agent-server-gui",
             "prompt": "Review pull requests labeled 'openhands-review' in OpenHands/agent-server-gui. Review tone: thorough.",
             "trigger": {
               "type": "cron",
@@ -179,7 +179,7 @@
             "automationId": "github-pr-reviewer",
             "endpoint": "/v1",
             "draft": {
-              "name": "GitHub Code Review Agent - 2 repositories",
+              "name": "GitHub code review - 2 repositories",
               "trigger": {
                 "type": "cron",
                 "schedule": "*/15 * * * *",
@@ -216,7 +216,7 @@
           "method": "POST",
           "path": "/v1",
           "body": {
-            "name": "GitHub Code Review Agent - 2 repositories",
+            "name": "GitHub code review - 2 repositories",
             "trigger": {
               "type": "cron",
               "schedule": "*/15 * * * *",
@@ -246,7 +246,7 @@
             "user_id": "1a2b3c4d-0000-4000-8000-000000000001",
             "org_id": "1a2b3c4d-0000-4000-8000-000000000002",
             "model": null,
-            "name": "GitHub Code Review Agent - 2 repositories",
+            "name": "GitHub code review - 2 repositories",
             "prompt": "Review pull requests labeled 'openhands-review' in OpenHands/agent-server-gui. Review tone: thorough.",
             "trigger": {
               "type": "cron",
@@ -300,7 +300,7 @@
             "automationId": "github-pr-reviewer",
             "endpoint": "/v1",
             "draft": {
-              "name": "GitHub Code Review Agent - OpenHands/agent-server-gui",
+              "name": "GitHub code review - OpenHands/agent-server-gui",
               "trigger": {
                 "type": "cron",
                 "schedule": "*/1 * * * *",
@@ -381,7 +381,7 @@
           "method": "POST",
           "path": "/v1",
           "body": {
-            "name": "GitHub Code Review Agent - OpenHands/agent-server-gui",
+            "name": "GitHub code review - OpenHands/agent-server-gui",
             "trigger": {
               "type": "cron",
               "schedule": "0 0 31 2 *",
@@ -465,7 +465,7 @@
           "method": "POST",
           "path": "/v1",
           "body": {
-            "name": "GitHub Code Review Agent - OpenHands/agent-server-gui",
+            "name": "GitHub code review - OpenHands/agent-server-gui",
             "trigger": {
               "type": "cron",
               "schedule": "*/15 * * * *",


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

Three automation catalog entries are named after an agent rather than after the work they do, so the template card tells a user who is acting instead of what will happen. They are also the only Title Case names in a catalog that is otherwise sentence case.

## Summary

- Renamed three catalog entries so the name is the action: `GitHub Issue to PR Agent` → `GitHub issue to PR`, `GitHub Code Review Agent` → `GitHub code review`, `QA Changes Agent` → `QA changes`.
- Updated the worked example in `automations/README.md`, which quotes the `github-pr-reviewer` entry.
- Updated `tests/fixtures/automations/github-pr-reviewer.json`, because a created automation's name is derived from the entry name (`_derive_name` in `tests/test_automation_setup.py`) and that test compares the derived request body to these fixtures byte for byte.

`AGENTS.md Maintainer` is left alone: that is the name of a file, not an agent mention. The `QA Agent` section header that the qa-changes automation writes into a PR description is also untouched, since the automation's filter expression depends on that exact string.

## Issue Number

Fixes #532

## How to Test

```
uv run --group test pytest
```

785 passed, 8 skipped locally with the live integration smoke deselected. `tests/test_automation_setup.py` and `tests/test_catalog_schema.py` cover the renamed entries and the updated fixtures.

## Video/Screenshots

Not applicable, this is a copy change in the catalog manifests.

## Notes

Agent Canvas pins `@openhands/extensions`, so the new names reach users on the next version bump.
