### PR TITLE
feat(integrations): add Pilot Protocol

### DIFF
--- a/integrations/catalog-index.js
+++ b/integrations/catalog-index.js
@@ -73,12 +73,13 @@ import entry67 from "./catalog/mongodb.json" with { type: "json" };
 import entry68 from "./catalog/neon.json" with { type: "json" };
 import entry69 from "./catalog/obsidian.json" with { type: "json" };
 import entry70 from "./catalog/paypal.json" with { type: "json" };
-import entry71 from "./catalog/playwright.json" with { type: "json" };
-import entry72 from "./catalog/redis.json" with { type: "json" };
-import entry73 from "./catalog/resend.json" with { type: "json" };
-import entry74 from "./catalog/sequential-thinking.json" with { type: "json" };
-import entry75 from "./catalog/superhuman-mail.json" with { type: "json" };
-import entry76 from "./catalog/time.json" with { type: "json" };
+import entry71 from "./catalog/pilot-protocol.json" with { type: "json" };
+import entry72 from "./catalog/playwright.json" with { type: "json" };
+import entry73 from "./catalog/redis.json" with { type: "json" };
+import entry74 from "./catalog/resend.json" with { type: "json" };
+import entry75 from "./catalog/sequential-thinking.json" with { type: "json" };
+import entry76 from "./catalog/superhuman-mail.json" with { type: "json" };
+import entry77 from "./catalog/time.json" with { type: "json" };
 
 export const INTEGRATION_CATALOG_ENTRIES = [
   entry0,
@@ -158,4 +159,5 @@ export const INTEGRATION_CATALOG_ENTRIES = [
   entry74,
   entry75,
   entry76,
+  entry77,
 ];

--- a/integrations/catalog/pilot-protocol.json
+++ b/integrations/catalog/pilot-protocol.json
@@ -1,0 +1,32 @@
+{
+  "id": "pilot-protocol",
+  "name": "Pilot Protocol",
+  "description": "Discover specialist agents and exchange messages with trusted peers.",
+  "appUrl": "https://pilotprotocol.network",
+  "docsUrl": "https://github.com/pilot-protocol/pilot-mcp",
+  "iconBg": "#111827",
+  "keywords": [
+    "agents",
+    "agent-to-agent",
+    "peer-to-peer",
+    "discovery"
+  ],
+  "connectionOptions": [
+    {
+      "id": "local",
+      "provider": "mcp",
+      "transport": {
+        "kind": "stdio",
+        "serverName": "pilot",
+        "command": "npx",
+        "args": [
+          "-y",
+          "pilotprotocol-mcp"
+        ]
+      },
+      "auth": {
+        "strategy": "none"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- [x] A human has tested these changes.

## Why

OpenHands users can run Pilot Protocol as a local stdio MCP server without credentials, but it is not available in the integration catalog.

## Summary

- Add a Pilot Protocol catalog entry
- Configure the published `pilotprotocol-mcp` package over stdio
- Regenerate the integration catalog index

## Issue Number

Related catalog infrastructure: #241

Submission request: https://github.com/OpenHands/extensions/issues/537

## How to Test

1. Run `uv run --group test pytest tests/ -q`.
2. Open the OpenHands integration marketplace and install Pilot Protocol.
3. Confirm the server starts and exposes `pilot_search` and `pilot_peers`.

Automated result: 801 passed, 24 skipped.

## Video/Screenshots

Not applicable for the catalog data change.

## Notes

Disclosure: I contribute to Pilot Protocol. AI-assisted; reviewed and validated against the repository schema and test suite.

HUMAN: No manual UI test was performed. The repository test suite, both synchronization checks, generated integration index, schema validation, and Claude plugin validation were run locally; the exact results are recorded above.